### PR TITLE
Update to include priority queue and quicker autoscaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ staging:
 production:
 	$(eval export CF_SPACE=production)
 	$(eval export SQS_QUEUE_PREFIX=live)
-	$(eval export CF_MIN_INSTANCE_COUNT=2)
+	$(eval export CF_MIN_INSTANCE_COUNT=4)
 	@true
 
 cf-push:

--- a/main.py
+++ b/main.py
@@ -154,8 +154,6 @@ class AutoScaler:
 
         desired_instance_count = int(math.ceil(highest_request_count / float(app.request_per_instance)))
 
-        # passing 0 as highest request count to always do downscale on API.
-        # on SQS based autoscaling we down scale when we get below a 1000 messages
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 
     def scale_paas_apps(self, app, paas_app, current_instance_count, desired_instance_count):

--- a/main.py
+++ b/main.py
@@ -175,6 +175,7 @@ class AutoScaler:
     def schedule(self):
         current_time = time.time()
         run_at = current_time + self.schedule_interval - ((current_time - self.schedule_delay) % self.schedule_interval)
+        print('Next run time {}'.format(str(run_at)))
         self.scheduler.enterabs(run_at, 1, self.run_task)
 
     def run_task(self):
@@ -207,10 +208,11 @@ class AutoScaler:
 min_instance_count = int(os.environ['CF_MIN_INSTANCE_COUNT'])
 
 sqs_apps = []
-sqs_apps.append(SQSApp('notify-delivery-worker-database', ['db-sms','db-email','db-letter'], 2000, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker', ['notify', 'retry', 'process-job', 'periodic'], 2000, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms','send-email'], 2000, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode'], 2000, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-database', ['db-sms','db-email','db-letter'], 500, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker', ['notify', 'retry', 'process-job', 'periodic'], 500, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms','send-email'], 500, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode'], 500, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority'], 500, min_instance_count, 20))
 
 elb_apps = []
 elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count, 20))

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -10,11 +10,11 @@ applications:
     memory: 128M
     env:
       AWS_REGION: eu-west-1
-      SCHEDULE_INTERVAL: 60
+      SCHEDULE_INTERVAL: 20
       CF_API_URL: https://api.cloud.service.gov.uk
       CF_ORG: govuk-notify
       CF_SPACE: <%= ENV.fetch("CF_SPACE") %>
-      SQS_QUEUE_PREFIX: cf-<%= ENV.fetch("CF_SPACE") %>-
+      SQS_QUEUE_PREFIX: <%= ENV.fetch("CF_SPACE") %>
       PYTHONUNBUFFERED: 1
       CF_MIN_INSTANCE_COUNT: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT", "1") %>
     services:

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -14,7 +14,7 @@ applications:
       CF_API_URL: https://api.cloud.service.gov.uk
       CF_ORG: govuk-notify
       CF_SPACE: <%= ENV.fetch("CF_SPACE") %>
-      SQS_QUEUE_PREFIX: <%= ENV.fetch("CF_SPACE") %>
+      SQS_QUEUE_PREFIX: <%= ENV.fetch("SQS_QUEUE_PREFIX") %>
       PYTHONUNBUFFERED: 1
       CF_MIN_INSTANCE_COUNT: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT", "1") %>
     services:


### PR DESCRIPTION
Autoscaler more aggressive in upscaling:
- checks every 20seconds
- 1 new delivery box for every 250 queued messages
- scale down 1 at a time not 2 at a time.