### PR TITLE
Include statsd calls into the autoscale events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ generate-manifest:
 preview:
 	$(eval export CF_SPACE=preview)
 	$(eval export SQS_QUEUE_PREFIX=preview)
-	$(eval export STATSD_ENABLED=True)
-	$(eval export STATSD_PREFIX=preview)
+	$(eval export STATSD_ENABLED=False)
 	@true
 
 staging:
@@ -30,7 +29,6 @@ staging:
 	$(eval export SQS_QUEUE_PREFIX=staging)
 	$(eval export CF_MIN_INSTANCE_COUNT=2)
 	$(eval export STATSD_ENABLED=True)
-	$(eval export STATSD_PREFIX=preview)
 	@true
 
 production:
@@ -38,7 +36,6 @@ production:
 	$(eval export SQS_QUEUE_PREFIX=live)
 	$(eval export CF_MIN_INSTANCE_COUNT=4)
 	$(eval export STATSD_ENABLED=True)
-	$(eval export STATSD_PREFIX=preview)
 	@true
 
 cf-push:

--- a/Makefile
+++ b/Makefile
@@ -21,18 +21,24 @@ generate-manifest:
 preview:
 	$(eval export CF_SPACE=preview)
 	$(eval export SQS_QUEUE_PREFIX=preview)
+	$(eval export STATSD_ENABLED=True)
+	$(eval export STATSD_PREFIX=preview)
 	@true
 
 staging:
 	$(eval export CF_SPACE=staging)
 	$(eval export SQS_QUEUE_PREFIX=staging)
 	$(eval export CF_MIN_INSTANCE_COUNT=2)
+	$(eval export STATSD_ENABLED=True)
+	$(eval export STATSD_PREFIX=preview)
 	@true
 
 production:
 	$(eval export CF_SPACE=production)
 	$(eval export SQS_QUEUE_PREFIX=live)
 	$(eval export CF_MIN_INSTANCE_COUNT=4)
+	$(eval export STATSD_ENABLED=True)
+	$(eval export STATSD_PREFIX=preview)
 	@true
 
 cf-push:

--- a/README.md
+++ b/README.md
@@ -45,3 +45,12 @@ When you change the service data you have to restage the application (or push it
 ```
 cf restage notify-paas-autoscaler
 ```
+
+
+## Runnning tests
+
+### Virtualenv
+
+```
+mkvirtualenv -p /usr/local/bin/python3 notifications-paas-autoscaler
+```

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import random
 import datetime
 from functools import reduce
 from cloudfoundry_client.client import CloudFoundryClient
+from notifications_utils.clients.statsd.statsd_client import StatsdClient
+
 
 class SQSApp:
     def __init__(self, name, queues, messages_per_instance, min_instance_count, max_instance_count):
@@ -48,6 +50,17 @@ class AutoScaler:
         self.cf_org = os.environ['CF_ORG']
         self.cf_space = os.environ['CF_SPACE']
         self.cf_client = None
+
+        application = []
+        application['config']['STATSD_ENABLED'] = os.environ['STATSD_ENABLED']
+        application['config']['NOTIFY_ENVIRONMENT'] = os.environ['CF_SPACE']
+        application['config']['NOTIFY_APP_NAME'] = 'autoscaler'
+        application['config']['STATSD_HOST'] = 'statsd.hostedgraphite.com'
+        application['config']['STATSD_PORT'] = '8125'
+        application['config']['STATSD_PREFIX'] = os.environ['STATSD_PREFIX']
+
+        self.statsd_client = statsd_client.init_app(application)
+
 
     def get_cloudfoundry_client(self):
         if self.cf_client is None:

--- a/main.py
+++ b/main.py
@@ -227,11 +227,12 @@ class AutoScaler:
 min_instance_count = int(os.environ['CF_MIN_INSTANCE_COUNT'])
 
 sqs_apps = []
-sqs_apps.append(SQSApp('notify-delivery-worker-database', ['db-sms','db-email','db-letter'], 250, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker', ['notify', 'retry', 'process-job', 'periodic'], 250, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms','send-email'], 250, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode'], 250, min_instance_count, 20))
-sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority'], 250, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-database', ['db-sms','db-email','db-letter', 'database-tasks'], 250, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker', ['notify', 'retry', 'process-job', 'notify-internal-tasks', 'retry-tasks', 'job-tasks', 'periodic-tasks'], 250, min_instance_count, 5))
+sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms','send-email', 'send-tasks'], 250, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode', 'research-mode-tasks'], 250, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority', 'prioriy-tasks'], 250, min_instance_count, 20))
+sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic', 'statistics', 'periodic-tasks', 'statistics-tasks'], 250, min_instance_count, 5))
 
 elb_apps = []
 elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count, 20))

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -15,9 +15,9 @@ applications:
       CF_ORG: govuk-notify
       CF_SPACE: <%= ENV.fetch("CF_SPACE") %>
       STATSD_ENABLED: <%= ENV.fetch("STATSD_ENABLED") %>
-      STATSD_PREFIX: <%= ENV.fetch("STATSD_PREFIX") %>
       SQS_QUEUE_PREFIX: <%= ENV.fetch("SQS_QUEUE_PREFIX") %>
       PYTHONUNBUFFERED: 1
       CF_MIN_INSTANCE_COUNT: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT", "1") %>
     services:
       - notify-paas-autoscaler
+      - hosted-graphite

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -14,6 +14,8 @@ applications:
       CF_API_URL: https://api.cloud.service.gov.uk
       CF_ORG: govuk-notify
       CF_SPACE: <%= ENV.fetch("CF_SPACE") %>
+      STATSD_ENABLED: <%= ENV.fetch("STATSD_ENABLED") %>
+      STATSD_PREFIX: <%= ENV.fetch("STATSD_PREFIX") %>
       SQS_QUEUE_PREFIX: <%= ENV.fetch("SQS_QUEUE_PREFIX") %>
       PYTHONUNBUFFERED: 1
       CF_MIN_INSTANCE_COUNT: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT", "1") %>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cloudfoundry-client==0.0.19
 boto3==1.4.3
 
-git+https://github.com/alphagov/notifications-utils.git@15.0.2#egg=notifications-utils==15.0.2
+git+https://github.com/alphagov/notifications-utils.git@15.0.3#egg=notifications-utils==15.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 cloudfoundry-client==0.0.19
 boto3==1.4.3
+
+git+https://github.com/alphagov/notifications-utils.git@15.0.2#egg=notifications-utils==15.0.2

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Bootstrap virtualenv environment and postgres databases locally.
+#
+# NOTE: This script expects to be run from the project root with
+# ./scripts/bootstrap.sh
+
+set -o pipefail
+
+function display_result {
+  RESULT=$1
+  EXIT_STATUS=$2
+  TEST=$3
+
+  if [ $RESULT -ne 0 ]; then
+    echo -e "\033[31m$TEST failed\033[0m"
+    exit $EXIT_STATUS
+  else
+    echo -e "\033[32m$TEST passed\033[0m"
+  fi
+}
+
+if [ ! $VIRTUAL_ENV ]; then
+  virtualenv -p python3 ./venv
+  . ./venv/bin/activate
+fi
+
+# Install Python development dependencies
+pip3 install -r requirements.txt


### PR DESCRIPTION
- logs the instance count and the queue size/request count

- These are the autoscale metrics and outcomes.

- instance count and request count are done as gauges, where as queue size is a counter.

https://www.hostedgraphite.com/cb4e5f9c/grafana/dashboard/db/notify-autoscaler?var-env=production&var-QueuePrefix=live&from=now-5m&to=now