### PR TITLE
Scale down adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Autoscaling agent for the Notify PaaS applications.
 
-Runs every SCHEDULE_INTERVAL (default: 60 seconds) interval, checks some metrics and sets the desired instance count accordingly.
+Runs every SCHEDULE_INTERVAL (default: 20 seconds) interval, checks some metrics and sets the desired instance count accordingly.
 
 Currently it scales the following applications:
  * notify-delivery-worker-database: we get the highest message count from the db-sms, db-email and db-letter queues and provision an instance for every 2000 messages. E.g. 10k messages mean 5 running instances.

--- a/main.py
+++ b/main.py
@@ -122,8 +122,9 @@ class AutoScaler:
     def get_highest_message_count(self, queues):
         result = 0
         for queue in queues:
-            message_count = self.get_sqs_message_count(self.get_sqs_queue_name(queue))
-            self.statsd_client.incr("{}.queue-length".format(self.get_sqs_queue_name(queue)), message_count)
+            queue_name = self.get_sqs_queue_name(queue)
+            message_count = self.get_sqs_message_count(queue_name)
+            self.statsd_client.incr("{}.queue-length".format(queue_name), message_count)
             result = max(result, message_count)
         return result
 

--- a/main.py
+++ b/main.py
@@ -187,7 +187,7 @@ class AutoScaler:
             self.last_scale_up[app.name] = datetime.datetime.now()
 
         if is_scale_down:
-            if self.last_scale_up.get(app.name, datetime.datetime.now()) + datetime.timedelta(minutes=5) < datetime.now():
+            if self.last_scale_up.get(app.name, datetime.datetime.now()) + datetime.timedelta(minutes=5) > datetime.now():
                 print("Skipping scale down due to recent scale up event")
                 return
 

--- a/main.py
+++ b/main.py
@@ -187,7 +187,11 @@ class AutoScaler:
             self.last_scale_up[app.name] = datetime.datetime.now()
 
         if is_scale_down:
-            if self.last_scale_up.get(app.name, datetime.datetime.now()) + datetime.timedelta(minutes=5) > datetime.now():
+            # if we redeployed the app and we lost the last scale up time
+            if not self.last_scale_up.get(app.name):
+                self.last_scale_up[app.name] = datetime.datetime.now()
+
+            if self.last_scale_up[app.name] + datetime.timedelta(minutes=5) > datetime.datetime.now():
                 print("Skipping scale down due to recent scale up event")
                 return
 


### PR DESCRIPTION
Prevent scale down if we have just scaled up, to give time to consumers to do their job before we kill them. Related commit: https://github.com/alphagov/notifications-paas-autoscaler/commit/d5e85652525e3a4675a45b2cabb74e8a66d2e9fc

The rest is just aesthetic changes and a small update to README.

