### PR TITLE
Tweak autoscaler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ staging:
 	$(eval export SQS_QUEUE_PREFIX=staging)
 	$(eval export CF_MAX_INSTANCE_COUNT_HIGH=20)
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
-	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=2)
-	$(eval export CF_MIN_INSTANCE_COUNT_LOW=1)
+	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
+	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
 	$(eval export STATSD_ENABLED=True)
 	@true
 

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,5 @@ production:
 cf-push:
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	cf target -s ${CF_SPACE}
+	cf unbind-service notify-paas-autoscaler notify-db
 	cf push -f <(make generate-manifest)

--- a/main.py
+++ b/main.py
@@ -187,7 +187,7 @@ class AutoScaler:
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 
     def get_scheduled_jobs_items_count(self):
-        interval = '3 minutes'
+        interval = '1 minute'
         db_uri = json.loads(os.environ['VCAP_SERVICES'])['postgres'][0]['credentials']['uri']
         with psycopg2.connect(db_uri) as conn:
             with conn.cursor() as cursor:
@@ -207,9 +207,9 @@ class AutoScaler:
                 return items_count
 
     def scale_schedule_job_app(self, app, paas_app, scheduled_items):
-        # use only half of the items because not everything gets put on the queue at once
-        half_items = scheduled_items / 2
-        desired_instance_count = int(math.ceil(half_items / float(app.items_per_instance)))
+        # use only a third of the items because not everything gets put on the queue at once
+        scale_items = scheduled_items / 3
+        desired_instance_count = int(math.ceil(scale_items / float(app.items_per_instance)))
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 
     def scale_paas_apps(self, app, paas_app, current_instance_count, desired_instance_count):


### PR DESCRIPTION
Make staging the same size as prod, 
* scale only 1 minute in advance instead of 3 
* scale only based on 1/3 of scheduled items.
* Scale min and max instances the same

**pivotal story:**
https://www.pivotaltracker.com/story/show/151839740