### PR TITLE
Add buffer instances for API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ preview:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=1)
+	$(eval export CF_BUFFER_INSTANCES=1)
 	$(eval export STATSD_ENABLED=False)
 	@true
 
@@ -35,6 +36,7 @@ staging:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
+	$(eval export CF_BUFFER_INSTANCES=2)
 	$(eval export STATSD_ENABLED=True)
 	@true
 
@@ -45,6 +47,7 @@ production:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
+	$(eval export CF_BUFFER_INSTANCES=2)
 	$(eval export STATSD_ENABLED=True)
 	@true
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ preview:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=1)
-	$(eval export CF_BUFFER_INSTANCES=1)
+	$(eval export CF_BUFFER_INSTANCES=0)
 	$(eval export STATSD_ENABLED=False)
 	@true
 

--- a/main.py
+++ b/main.py
@@ -14,11 +14,11 @@ from notifications_utils.clients.statsd.statsd_client import StatsdClient
 
 
 class App:
-    def __init__(self, name, min_instance_count, max_instance_count):
+    def __init__(self, name, min_instance_count, max_instance_count, buffer_instances=0):
         self.name = name
         self.min_instance_count = min_instance_count
         self.max_instance_count = max_instance_count
-        self.buffer_instances = 0
+        self.buffer_instances = buffer_instances
 
 
 class SQSApp(App):
@@ -29,11 +29,11 @@ class SQSApp(App):
 
 
 class ELBApp(App):
-    def __init__(self, name, load_balancer_name, request_per_instance, min_instance_count, max_instance_count):
-        super().__init__(name, min_instance_count, max_instance_count)
+    def __init__(self, name, load_balancer_name, request_per_instance, min_instance_count,
+                 max_instance_count, buffer_instances):
+        super().__init__(name, min_instance_count, max_instance_count, buffer_instances)
         self.load_balancer_name = load_balancer_name
         self.request_per_instance = request_per_instance
-        self.buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
 
 
 class ScheduledJobApp(App):
@@ -297,6 +297,7 @@ max_instance_count_high = int(os.environ['CF_MAX_INSTANCE_COUNT_HIGH'])
 max_instance_count_low = int(os.environ['CF_MAX_INSTANCE_COUNT_LOW'])
 min_instance_count_high = int(os.environ['CF_MIN_INSTANCE_COUNT_HIGH'])
 min_instance_count_low = int(os.environ['CF_MIN_INSTANCE_COUNT_LOW'])
+buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
 
 sqs_apps = []
 sqs_apps.append(SQSApp('notify-delivery-worker-database', ['database-tasks'], 250, min_instance_count_low, max_instance_count_high))
@@ -307,7 +308,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 25
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
 
 elb_apps = []
-elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count_high, max_instance_count_high))
+elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count_high, max_instance_count_high, buffer_instances))
 
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ class ELBApp(App):
         super().__init__(name, min_instance_count, max_instance_count)
         self.load_balancer_name = load_balancer_name
         self.request_per_instance = request_per_instance
+        self.buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
 
 
 class ScheduledJobApp(App):
@@ -183,6 +184,7 @@ class AutoScaler:
         print('Highest request count (5 min): {}'.format(highest_request_count))
 
         desired_instance_count = int(math.ceil(highest_request_count / float(app.request_per_instance)))
+        desired_instance_count += app.buffer_instances
         self.statsd_client.gauge("{}.request-count".format(app.name), highest_request_count)
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ class ELBApp(App):
         self.load_balancer_name = load_balancer_name
         self.request_per_instance = request_per_instance
         self.buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
+        self.max_instance_count += self.buffer_instances
 
 
 class ScheduledJobApp(App):

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -21,6 +21,7 @@ applications:
       CF_MIN_INSTANCE_COUNT_HIGH: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT_HIGH", "1") %>
       CF_MAX_INSTANCE_COUNT_LOW: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_LOW", "1") %>
       CF_MAX_INSTANCE_COUNT_HIGH: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_HIGH", "1") %>
+      CF_BUFFER_INSTANCES: <%= ENV.fetch("CF_BUFFER_INSTANCES", "1") %>
     services:
       - notify-paas-autoscaler
       - hosted-graphite


### PR DESCRIPTION
Right now the API instances would start from a baselive of 4 and would
not scale up until the requests per minute threshold was crossed
(i.e. 1500 * number of instances). This approach does not work for
spiked traffic as we need to wait a full minute to get the new request
count from ELB.

This PR gives the option to configure a different number of extra
instances per environment for the notify-api app, to act as a buffer
until we scale them up.