### PR TITLE
More aggressive API scaling

### DIFF
--- a/main.py
+++ b/main.py
@@ -309,7 +309,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'st
 sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_low))
 
 elb_apps = []
-elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count_high, max_instance_count_high, buffer_instances))
+elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 750, min_instance_count_high, max_instance_count_high, buffer_instances))
 
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))


### PR DESCRIPTION
1500 reqs/minute/instance was leading to slower response times than
we wanted. By dropping that number to 750 improved things on staging.