### PR TITLE
Increased notify-delivery-worker-receipts max to 30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ preview:
 staging:
 	$(eval export CF_SPACE=staging)
 	$(eval export SQS_QUEUE_PREFIX=staging)
+	$(eval export CF_MAX_INSTANCE_COUNT_V_HIGH=30)
 	$(eval export CF_MAX_INSTANCE_COUNT_HIGH=20)
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)

--- a/main.py
+++ b/main.py
@@ -293,6 +293,7 @@ class AutoScaler:
             self.scheduler.run()
 
 
+max_instance_count_v_high = int(os.environ['CF_MAX_INSTANCE_COUNT_V_HIGH'])
 max_instance_count_high = int(os.environ['CF_MAX_INSTANCE_COUNT_HIGH'])
 max_instance_count_low = int(os.environ['CF_MAX_INSTANCE_COUNT_LOW'])
 min_instance_count_high = int(os.environ['CF_MIN_INSTANCE_COUNT_HIGH'])
@@ -306,7 +307,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms-tasks', 'send
 sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
-sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_low))
+sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_v_high))
 
 elb_apps = []
 elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count_high, max_instance_count_high, buffer_instances))

--- a/main.py
+++ b/main.py
@@ -319,7 +319,7 @@ scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-sender', 250, 
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-research', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-priority', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-periodic', 250, min_instance_count_low, max_instance_count_low))
-scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-receipts', 250, min_instance_count_low, max_instance_count_low))
+scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-receipts', 250, min_instance_count_low, max_instance_count_v_high))
 
 autoscaler = AutoScaler(sqs_apps, elb_apps, scheduled_job_apps)
 autoscaler.run()

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -21,6 +21,7 @@ applications:
       CF_MIN_INSTANCE_COUNT_HIGH: <%= ENV.fetch("CF_MIN_INSTANCE_COUNT_HIGH", "1") %>
       CF_MAX_INSTANCE_COUNT_LOW: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_LOW", "1") %>
       CF_MAX_INSTANCE_COUNT_HIGH: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_HIGH", "1") %>
+      CF_MAX_INSTANCE_COUNT_V_HIGH: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_V_HIGH", "1") %>
       CF_BUFFER_INSTANCES: <%= ENV.fetch("CF_BUFFER_INSTANCES", "1") %>
     services:
       - notify-paas-autoscaler


### PR DESCRIPTION
After tests sending 1 million email an hour, the number of receipt workers did not keep up with the demand meaning that the functional tests failed due to the delay in processing the receipt. Increased the max number of receipt workers to 30 to ensure there are enough workers to cope with the demand. Both 20 and 25 instances were tested and showed a significant increase in queue size over a sustained run i.e. 15-30 mins at 200 req/sec.

- Updated the notify-delivery-worker-receipts to use the v_high value
- Added a V_HIGH value of 30
- Updated manifest to include export the value
  