### PR TITLE
Added the CF_MAX_INSTANCE_COUNT_V_HIGH to preview and production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ generate-manifest:
 preview:
 	$(eval export CF_SPACE=preview)
 	$(eval export SQS_QUEUE_PREFIX=preview)
+	$(eval export CF_MAX_INSTANCE_COUNT_V_HIGH=3)
 	$(eval export CF_MAX_INSTANCE_COUNT_HIGH=2)
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=1)
@@ -44,6 +45,7 @@ staging:
 production:
 	$(eval export CF_SPACE=production)
 	$(eval export SQS_QUEUE_PREFIX=live)
+	$(eval export CF_MAX_INSTANCE_COUNT_V_HIGH=30)
 	$(eval export CF_MAX_INSTANCE_COUNT_HIGH=20)
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)


### PR DESCRIPTION
The changes to the receipt worker were tested and rolled out to staging
but preview and production will currently use the default of 1 for the
CF_MAX_INSTANCE_COUNT_V_HIGH. This update brings the production in line
with the staging value and sets a value on preview higher that the low
value.

This will allow the receipt worker to scale to the CF_MAX_INSTANCE_COUNT_V_HIGH value based on the ses-callbacks queue. After testing on staging and sending our proposed peak of 1 million emails an hour the CF_MAX_INSTANCE_COUNT_HIGH value did you keep up with the demand meaning at the end of the period 100k plus items were in the queue.