### PR TITLE
Don't bind unused hosted-graphite PaaS user service

### DIFF
--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -25,5 +25,4 @@ applications:
       CF_BUFFER_INSTANCES: <%= ENV.fetch("CF_BUFFER_INSTANCES", "1") %>
     services:
       - notify-paas-autoscaler
-      - hosted-graphite
       - notify-db


### PR DESCRIPTION
hosted-graphite service contains a JSON data blob with `statsd_prefix`,
but it's not actually used by the application. Instead, STASD_PREFIX
is read from the PaaS application environment variables.

We can unbind the service so that it can be removed now that it's not
used by any other apps on PaaS.