### PR TITLE
Upgrading the python version

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.4


### PR DESCRIPTION
On deploy an error is generated **ERROR** Could not install python:
no match found for 3.5.2 in [2.7.14 2.7.13 3.3.7 3.3.6 3.4.6 3.4.7 3.5.3
3.5.4 3.6.2 3.6.3]. Upgraded to version 3.5.4 so that the error does not
occur and tested on preview and monitored for errors.