### PR TITLE
Tweak autoscaler

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,8 @@ class SQSApp(App):
 class ELBApp(App):
     def __init__(self, name, load_balancer_name, request_per_instance, min_instance_count,
                  max_instance_count, buffer_instances):
+        cf_space = os.environ['CF_SPACE']
+        min_instance_count = 10 if cf_space == "production" else min_instance_count
         super().__init__(name, min_instance_count, max_instance_count, buffer_instances)
         self.load_balancer_name = load_balancer_name
         self.request_per_instance = request_per_instance

--- a/main.py
+++ b/main.py
@@ -325,7 +325,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250
 sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 10, min_instance_count_low, max_instance_count_medium))
 
 elb_apps = []
-elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1500, min_instance_count_high, max_instance_count_high, buffer_instances))
+elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1250, min_instance_count_high, max_instance_count_high, buffer_instances))
 
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))


### PR DESCRIPTION
**Set a minimum of 10 api instances on production**
Temporary hack to lower the number of 500s when downscaling while we
investigate the underlying cause.

**Lower the number of requests per api instance**
This will allow us to scale up more aggressively, thus maintaining a low
response time.