### PR TITLE
Lower autoscaler interval to 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Autoscaling agent for the Notify PaaS applications.
 
-Runs every SCHEDULE_INTERVAL (default: 20 seconds) interval, checks some metrics and sets the desired instance count accordingly.
+Runs every SCHEDULE_INTERVAL (default: 10 seconds) interval, checks some metrics and sets the desired instance count accordingly.
 
 Currently it scales the following applications:
  * notify-delivery-worker-database: we get the highest message count from the db-sms, db-email and db-letter queues and provision an instance for every 2000 messages. E.g. 10k messages mean 5 running instances.

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -10,7 +10,7 @@ applications:
     memory: 128M
     env:
       AWS_REGION: eu-west-1
-      SCHEDULE_INTERVAL: 20
+      SCHEDULE_INTERVAL: 10
       COOLDOWN_SECONDS_AFTER_SCALE_UP: 300
       COOLDOWN_SECONDS_AFTER_SCALE_DOWN: 60
       CF_API_URL: https://api.cloud.service.gov.uk


### PR DESCRIPTION
This is to allow us to respond to spikes faster