### PR TITLE
Scale API on 2000 requests per minute

### DIFF
--- a/main.py
+++ b/main.py
@@ -325,7 +325,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250
 sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 10, min_instance_count_low, max_instance_count_medium))
 
 elb_apps = []
-elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 1250, min_instance_count_high, max_instance_count_high, buffer_instances))
+elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 2000, min_instance_count_high, max_instance_count_high, buffer_instances))
 
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))


### PR DESCRIPTION
After [introducing async workers][1] we can, in theory, serve:
12 (min instances) * 5 (workers per instance) * 256 (requests in parallel)
= 15,360 requests.

This is a small bump on the number of requests that should correspond
with the potential of increasing it much more in the future.

[1]: https://github.com/alphagov/notifications-api/pull/1627