### PR TITLE
Lower sender limits

### DIFF
--- a/main.py
+++ b/main.py
@@ -322,6 +322,7 @@ sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode-tasks'
 sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_v_high))
+sqs_apps.append(SQSApp('notify-delivery-worker-service-callbacks', ['service-callbacks'], 500, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 10, min_instance_count_low, max_instance_count_medium))
 
 elb_apps = []
@@ -335,6 +336,7 @@ scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-research', 250
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-priority', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-periodic', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-receipts', 250, min_instance_count_low, max_instance_count_v_high))
+scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-service-callbacks', 500, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-template-preview', 10, min_instance_count_low, max_instance_count_medium))
 
 autoscaler = AutoScaler(sqs_apps, elb_apps, scheduled_job_apps)

--- a/main.py
+++ b/main.py
@@ -214,8 +214,8 @@ class AutoScaler:
                 return items_count
 
     def scale_schedule_job_app(self, app, paas_app, scheduled_items):
-        # use only a third of the items because not everything gets put on the queue at once
-        scale_items = scheduled_items / 3
+        # use only half of the items because not everything gets put on the queue at once
+        scale_items = scheduled_items / 2
         desired_instance_count = int(math.ceil(scale_items / float(app.items_per_instance)))
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 
@@ -245,7 +245,7 @@ class AutoScaler:
                 print("Skipping scale down due to a recent scale down event")
                 return
 
-            # Make sure we don't remove more than 1 instance at a time, and only downscale when under 1000 messages
+            # Make sure we don't remove more than 1 instance at a time
             if current_instance_count - desired_instance_count >= 2:
                 desired_instance_count = current_instance_count - 1
                 self.last_scale_down[app.name] = datetime.datetime.now()
@@ -317,7 +317,7 @@ buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
 sqs_apps = []
 sqs_apps.append(SQSApp('notify-delivery-worker-database', ['database-tasks'], 250, min_instance_count_low, max_instance_count_high))
 sqs_apps.append(SQSApp('notify-delivery-worker', ['notify-internal-tasks', 'retry-tasks', 'job-tasks'], 250, min_instance_count_low, max_instance_count_low))
-sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms-tasks', 'send-email-tasks'], 250, min_instance_count_high, max_instance_count_high))
+sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms-tasks', 'send-email-tasks'], 110, min_instance_count_high, max_instance_count_high))
 sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
@@ -330,7 +330,7 @@ elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 2000, min_instance_cou
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker', 250, min_instance_count_low, max_instance_count_low))
-scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-sender', 250, min_instance_count_high, max_instance_count_high))
+scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-sender', 110, min_instance_count_high, max_instance_count_high))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-research', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-priority', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-periodic', 250, min_instance_count_low, max_instance_count_low))

--- a/main.py
+++ b/main.py
@@ -317,11 +317,11 @@ buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
 sqs_apps = []
 sqs_apps.append(SQSApp('notify-delivery-worker-database', ['database-tasks'], 250, min_instance_count_low, max_instance_count_high))
 sqs_apps.append(SQSApp('notify-delivery-worker', ['notify-internal-tasks', 'retry-tasks', 'job-tasks'], 250, min_instance_count_low, max_instance_count_low))
-sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms-tasks', 'send-email-tasks'], 110, min_instance_count_high, max_instance_count_high))
+sqs_apps.append(SQSApp('notify-delivery-worker-sender', ['send-sms-tasks', 'send-email-tasks'], 110, min_instance_count_high, max_instance_count_v_high))
 sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
-sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_v_high))
+sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_high))
 sqs_apps.append(SQSApp('notify-delivery-worker-service-callbacks', ['service-callbacks'], 500, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 10, min_instance_count_low, max_instance_count_medium))
 
@@ -331,11 +331,11 @@ elb_apps.append(ELBApp('notify-api', 'notify-paas-proxy', 2000, min_instance_cou
 scheduled_job_apps = []
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-database', 250, min_instance_count_low, max_instance_count_high))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker', 250, min_instance_count_low, max_instance_count_low))
-scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-sender', 110, min_instance_count_high, max_instance_count_high))
+scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-sender', 110, min_instance_count_high, max_instance_count_v_high))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-research', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-priority', 250, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-periodic', 250, min_instance_count_low, max_instance_count_low))
-scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-receipts', 250, min_instance_count_low, max_instance_count_v_high))
+scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-receipts', 250, min_instance_count_low, max_instance_count_high))
 scheduled_job_apps.append(ScheduledJobApp('notify-delivery-worker-service-callbacks', 500, min_instance_count_low, max_instance_count_low))
 scheduled_job_apps.append(ScheduledJobApp('notify-template-preview', 10, min_instance_count_low, max_instance_count_medium))
 

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -10,7 +10,7 @@ applications:
     memory: 128M
     env:
       AWS_REGION: eu-west-1
-      SCHEDULE_INTERVAL: 5
+      SCHEDULE_INTERVAL: 3
       COOLDOWN_SECONDS_AFTER_SCALE_UP: 300
       COOLDOWN_SECONDS_AFTER_SCALE_DOWN: 60
       CF_API_URL: https://api.cloud.service.gov.uk


### PR DESCRIPTION
This is to reduce the number of items in the queue per sender worker to 110 (11 concurrent workers * 10 items (at best)) per second). 

To balance things out, swap the maximum number of instances to `v_high` (30) for the sender and to `high` (20) for receipts, and increase the number of scheduled items we scale on (used to be `items/3` and now is `items/2`).

Finally and a bit unrelated to the rest, add the service-callback worker to the autoscaler so that we get a graph of its queue size and scale it every 500 items to a maximum of `low` (5) instances.