### PR TITLE
Add support for simple scheduled scaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ staging:
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
 	$(eval export CF_SCHEDULED_SCALE_FACTOR=0)
-	$(eval export CF_BUFFER_INSTANCES=2)
+	$(eval export CF_BUFFER_INSTANCES=0)
 	$(eval export STATSD_ENABLED=True)
 	@true
 
@@ -55,7 +55,7 @@ production:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
-	$(eval export CF_BUFFER_INSTANCES=2)
+	$(eval export CF_BUFFER_INSTANCES=0)
 	$(eval export CF_SCHEDULED_SCALE_FACTOR=0.6)
 	$(eval export STATSD_ENABLED=True)
 	@true

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ preview:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=1)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=1)
+	$(eval export CF_SCHEDULED_SCALE_FACTOR=0)
 	$(eval export CF_BUFFER_INSTANCES=0)
 	$(eval export STATSD_ENABLED=False)
 	@true
@@ -40,6 +41,7 @@ staging:
 	$(eval export CF_MAX_INSTANCE_COUNT_LOW=5)
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
+	$(eval export CF_SCHEDULED_SCALE_FACTOR=0)
 	$(eval export CF_BUFFER_INSTANCES=2)
 	$(eval export STATSD_ENABLED=True)
 	@true
@@ -54,6 +56,7 @@ production:
 	$(eval export CF_MIN_INSTANCE_COUNT_HIGH=4)
 	$(eval export CF_MIN_INSTANCE_COUNT_LOW=2)
 	$(eval export CF_BUFFER_INSTANCES=2)
+	$(eval export CF_SCHEDULED_SCALE_FACTOR=0.6)
 	$(eval export STATSD_ENABLED=True)
 	@true
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ The Autoscaler will scale the specified apps to the number of instances equal to
 unless some other metric requires the instance to scale to a higher number (e.g. a large scheduled job)
 
 
+## Debugging
+
+Depending on the problem you're facing you can use different approaches to get more information about it:
+
+1. You can see any events related to the autoscaler app using `cf events notify-paas-autoscaler`. This
+will show you deployments or restarts
+1. You can tail the logs with `cf logs notify-paas-autoscaler` or, if autoscaler has crashed, look into the latest logs with `cf logs notify-paas-autoscaler --latest`
+1. You can also log onto the box with `cf ssh notify-paas-autoscaler` and see if there are any exceptions logged in
+`/home/vcap/logs/app.log`
+
+
 ## Authentication credentials
 
 The application uses a user provided service to read the secret credentials it needs.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 Autoscaling agent for the Notify PaaS applications.
 
-Runs every SCHEDULE_INTERVAL (default: 10 seconds) interval, checks some metrics and sets the desired instance count accordingly.
-
-Currently it scales the following applications:
- * notify-delivery-worker-database: we get the highest message count from the db-sms, db-email and db-letter queues and provision an instance for every 2000 messages. E.g. 10k messages mean 5 running instances.
- * notify-delivery-worker: we get the highest message count from the send-sms, send-email queues and provision an instance for every 2000 messages. E.g. 10k messages mean 5 running instances.
+Runs every `SCHEDULE_INTERVAL` (currently 5 seconds) interval, checks some metrics and sets the desired instance count accordingly.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@ make <env> cf-push
 
 Where env can be preview, staging or production.
 
+## Scheduled scaling
+
+The Autoscaler can scale the worker applications based on a schedule defined in the `schedule.yml` file.
+
+The format of the file is:
+
+```
+name-of-the-app:
+  <workdays|weekends>:
+      - HH:MM-HH:MM
+      - HH:MM-HH:MM
+      - ...
+name-of-another-app:
+  <workdays|weekends>:
+      - HH:MM-HH:MM
+      - ...
+```
+
+For example, if you need to schedule the research worker to scale on weekends between
+9 in the morning and 2 in the afternoon you would add this to the `schedule.yml`:
+
+```
+notify-delivery-worker-research:
+  weekends:
+    - 09:00-14:00
+```
+
+The Autoscaler will scale the specified apps to the number of instances equal to `SCHEDULED_SCALE_FACTOR` * `max_instance_count`
+unless some other metric requires the instance to scale to a higher number (e.g. a large scheduled job)
+
+
 ## Authentication credentials
 
 The application uses a user provided service to read the secret credentials it needs.

--- a/main.py
+++ b/main.py
@@ -33,8 +33,6 @@ class SQSApp(App):
 class ELBApp(App):
     def __init__(self, name, load_balancer_name, request_per_instance, min_instance_count,
                  max_instance_count, buffer_instances):
-        cf_space = os.environ['CF_SPACE']
-        min_instance_count = 10 if cf_space == "production" else min_instance_count
         super().__init__(name, min_instance_count, max_instance_count, buffer_instances)
         self.load_balancer_name = load_balancer_name
         self.request_per_instance = request_per_instance

--- a/main.py
+++ b/main.py
@@ -226,6 +226,11 @@ class AutoScaler:
 
     def scale_elb_app(self, app, paas_app):
         print('Processing {}'.format(app.name))
+        scheduled_desired_instance_count = 0
+        if self.should_scale_on_schedule(app.name):
+            scheduled_desired_instance_count = int(math.ceil(app.max_instance_count * self.scheduled_scale_factor))
+            print("{} to scale to {} on schedule".format(app.name, scheduled_desired_instance_count))
+
         request_counts = self.get_load_balancer_request_counts(app.load_balancer_name)
         if len(request_counts) == 0:
             request_counts = [0]
@@ -235,7 +240,8 @@ class AutoScaler:
         highest_request_count = max(request_counts)
         print('Highest request count (5 min): {}'.format(highest_request_count))
 
-        desired_instance_count = int(math.ceil(highest_request_count / float(app.request_per_instance)))
+        requests_desired_instance_count = int(math.ceil(highest_request_count / float(app.request_per_instance)))
+        desired_instance_count = max(scheduled_desired_instance_count, requests_desired_instance_count)
         self.statsd_client.gauge("{}.request-count".format(app.name), highest_request_count)
         self.scale_paas_apps(app, paas_app, paas_app['instances'], desired_instance_count)
 

--- a/main.py
+++ b/main.py
@@ -364,7 +364,7 @@ max_instance_count_medium = int(os.environ['CF_MAX_INSTANCE_COUNT_MEDIUM'])
 max_instance_count_low = int(os.environ['CF_MAX_INSTANCE_COUNT_LOW'])
 min_instance_count_high = int(os.environ['CF_MIN_INSTANCE_COUNT_HIGH'])
 min_instance_count_low = int(os.environ['CF_MIN_INSTANCE_COUNT_LOW'])
-buffer_instances = int(os.environ['CF_BUFFER_INSTANCES'])
+buffer_instances = int(os.environ['BUFFER_INSTANCES'])
 
 sqs_apps = []
 sqs_apps.append(SQSApp('notify-delivery-worker-database', ['database-tasks'], 250, min_instance_count_low, max_instance_count_high))

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -11,7 +11,7 @@ applications:
     env:
       AWS_REGION: eu-west-1
       SCHEDULE_INTERVAL: 5
-      SCHEDULED_SCALE_FACTOR: 0.6
+      SCHEDULED_SCALE_FACTOR: <%= ENV.fetch("CF_SCHEDULED_SCALE_FACTOR", "0") %>
       COOLDOWN_SECONDS_AFTER_SCALE_UP: 300
       COOLDOWN_SECONDS_AFTER_SCALE_DOWN: 60
       CF_API_URL: https://api.cloud.service.gov.uk

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -11,6 +11,7 @@ applications:
     env:
       AWS_REGION: eu-west-1
       SCHEDULE_INTERVAL: 5
+      SCHEDULED_SCALE_FACTOR: 0.6
       COOLDOWN_SECONDS_AFTER_SCALE_UP: 300
       COOLDOWN_SECONDS_AFTER_SCALE_DOWN: 60
       CF_API_URL: https://api.cloud.service.gov.uk

--- a/manifest.yml.erb
+++ b/manifest.yml.erb
@@ -26,7 +26,7 @@ applications:
       CF_MAX_INSTANCE_COUNT_MEDIUM: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_MEDIUM", "1") %>
       CF_MAX_INSTANCE_COUNT_HIGH: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_HIGH", "1") %>
       CF_MAX_INSTANCE_COUNT_V_HIGH: <%= ENV.fetch("CF_MAX_INSTANCE_COUNT_V_HIGH", "1") %>
-      CF_BUFFER_INSTANCES: <%= ENV.fetch("CF_BUFFER_INSTANCES", "1") %>
+      BUFFER_INSTANCES: <%= ENV.fetch("CF_BUFFER_INSTANCES", "1") %>
     services:
       - notify-paas-autoscaler
       - notify-db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-cloudfoundry-client==0.0.20
 boto3==1.4.3
+cloudfoundry-client==0.0.20
 psycopg2==2.7.3.1
+pyyaml==3.12
 
 git+https://github.com/alphagov/notifications-utils.git@15.0.3#egg=notifications-utils==15.0.3

--- a/schedule.yml
+++ b/schedule.yml
@@ -4,3 +4,8 @@ notify-delivery-worker-sender:
     - 08:00-10:00
     - 12:00-13:00
     - 16:00-17:30
+notify-api:
+  workdays:
+    - 08:00-19:00
+  weekends:
+    - 09:00-17:00

--- a/schedule.yml
+++ b/schedule.yml
@@ -1,7 +1,7 @@
 ---
 notify-delivery-worker-sender:
   workdays:
-    - 08:00-10:00
+    - 08:30-10:30
     - 12:00-13:00
     - 16:00-17:30
 notify-api:

--- a/schedule.yml
+++ b/schedule.yml
@@ -1,0 +1,6 @@
+---
+notify-delivery-worker-sender:
+  workdays:
+    - 08:00-10:00
+    - 12:00-13:00
+    - 16:00-17:30


### PR DESCRIPTION
When the Autoscaler starts, it will load `schedule.yml` that
contains per-app configuration for scheduling its scaling.

The format of the file is:

```
name-of-the-app:
  <workdays|weekends>:
      - HH:MM-HH:MM
      - HH:MM-HH:MM
      - ...
name-of-another-app:
  <workdays|weekends>:
      - HH:MM-HH:MM
      - ...
```

The check of whether or not `now()` is within the time ranges defined in
`schedule.yml` happens every `SCHEDULE_INTERVAL` like every other check
and will scale the app to at least `SCHEDULED_SCALE_FACTOR * max_instance_count`
**unless** the other metrics of the app requires it to scale to a higher
number of instances, in which case it will scale to that.

The schedule file contained in this PR only defines scheduling rules for
the `notify-delivery-worker-sender`

Example of scheduled scaling (the scheduled period ends at 15:00)

<img width="652" alt="screen shot 2018-02-20 at 15 33 27" src="https://user-images.githubusercontent.com/4289633/36433166-ca442f8c-1653-11e8-9c8d-c511a6345015.png">