### PR TITLE
Template Preview config changes to reduce errors in PDF generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -371,7 +371,8 @@ sqs_apps.append(SQSApp('notify-delivery-worker-research', ['research-mode-tasks'
 sqs_apps.append(SQSApp('notify-delivery-worker-priority', ['priority-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-periodic', ['periodic-tasks', 'statistics-tasks'], 250, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-delivery-worker-receipts', ['ses-callbacks'], 250, min_instance_count_low, max_instance_count_v_high))
-sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 10, min_instance_count_low, max_instance_count_medium))
+sqs_apps.append(SQSApp('notify-template-preview', ['create-letters-pdf-tasks'], 8, min_instance_count_low,
+                       max_instance_count_v_high))
 sqs_apps.append(SQSApp('notify-delivery-worker-service-callbacks', ['service-callbacks'], 500, min_instance_count_low, max_instance_count_low))
 sqs_apps.append(SQSApp('notify-antivirus', ['antivirus-tasks'], 50, min_instance_count_low, max_instance_count_low))
 


### PR DESCRIPTION
A few Template Preview scaling tweaks to help it respond to demand quicker as currently there are errors when too many requests are sent to a specific instance. E.g. send 1000 letter requests via API with 10 users each 100 times (to create high demand). This is option 4 simulation on the latest version of the performance tests. 64 of the 1000 fail (they get retried but cause errors which can lead to actual errors being ignored). With the changes no errors are produced.

Results from testing can be seen in the Decisions section of this document: https://docs.google.com/document/d/1fURzMjO2Cufnq9C5PFoKEszlgBzqbCaWpASI_EFRmEc/edit?usp=sharing

* Allow the template preview application to scale beyond that of the delivery worker sending the requests. Its current limit of 10 was based on the template preview app using 2GB per instance and reaching our reserved memory quota or 200GB. This has since been extended to 500GB and the template preview app historically does not use more than 1GB per instance.
* Decrease the items per instance count, so that to scale the template preview app more aggressively.  Changing the items to per instance from 10 to 8 would mean for 80 items in the queue the app would scale to 10 instances where currently this would have been 8.