### PR TITLE
Adjust api scale factor

### DIFF
--- a/app/paas_client.py
+++ b/app/paas_client.py
@@ -55,7 +55,10 @@ class PaasClient:
                                 'instances': app['entity']['instances']
                             }
             except BaseException as e:
-                msg = 'Failed to get stats for app {}: {}'.format(app['entity']['name'], str(e))
+                if 'app' not in locals():
+                    msg = 'Failed to get instance info: {}'.format(str(e))
+                else:
+                    msg = 'Failed to get info for app {}: {}'.format(app['entity']['name'], str(e))
                 logging.error(msg)
                 self.reset_cloudfoundry_client()
 

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -32,6 +32,7 @@ APPS:
     scalers: [ElbScaler, ScheduleScaler]
     elb_name: 'notify-paas-proxy'
     schedule:
+      scale_factor: 0.5
       workdays:
         - 08:00-19:00
       weekends:


### PR DESCRIPTION
#### Change scheduled api scaling from 12 to 10 instances

With some of the improvements and tweaks we done the previous months, we
rarely go above 15k requests/minute nowadays.

Average CPU utilisation is at ~20% so we can drop the scheduled scaling
from 12 instances to 10.

#### Handle paas_client exception better

When the authorization token expires, we can end up in a situation
where we are in the `except` clause but the `app` variable has not been
instantiated yet.