### PR TITLE
Add letter-tasks queue to template-preview and delivery worker scalers

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -63,7 +63,7 @@ APPS:
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
     threshold: 250
     scalers: [SqsScaler]
-    queues:  [notify-internal-tasks, retry-tasks, job-tasks]
+    queues:  [notify-internal-tasks, retry-tasks, job-tasks, letter-tasks]
 
   - name: notify-delivery-worker-research
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
@@ -98,7 +98,7 @@ APPS:
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     threshold: 8
     scalers: [SqsScaler, ScheduledJobsScaler]
-    queues:  [create-letters-pdf-tasks]
+    queues:  [create-letters-pdf-tasks, letter-tasks]
 
   - name: notify-delivery-worker-service-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}


### PR DESCRIPTION
letter-tasks is used by antivirus to create virus scan results, which
are processed by API delivery workers. For successful virus scans API
workers will call template-preview to validate and sanitize the PDF,
so both the workers and template preview should scale based on the
size of the letter-tasks queue.