### PR TITLE
Lower the threshold for API to 1000 requests/instance

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -28,7 +28,7 @@ APPS:
   - name: notify-api
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 2000
+    threshold: 1000
     scalers: [ElbScaler, ScheduleScaler]
     elb_name: 'notify-paas-proxy'
     schedule:


### PR DESCRIPTION
Currently when we go above 10k requests we have a spike in CPU usage
across all API instances.

Given that this load is spread over the 10 instances that we usually run,
that means that each instance can handle ~1000 requests.

This commit will lower the scaling threhold to that number and if
there's a lot of scaling activity it can be made permanent by
bumping the `scale_factor` for the `ScheduleScaler`.