### PR TITLE
Bump pyyaml and notifications-utils versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.4.3
 cloudfoundry-client==0.0.22
 psycopg2==2.7.3.1
-pyyaml==3.12
+pyyaml==3.13
 
-git+https://github.com/alphagov/notifications-utils.git@29.1.1#egg=notifications-utils==29.1.1
+git+https://github.com/alphagov/notifications-utils.git@31.2.4#egg=notifications-utils==31.2.4


### PR DESCRIPTION
Merging this will also use the new paas user: https://github.com/alphagov/notifications-credentials/pull/83