### PR TITLE
Rearrange queues in delivery worker apps

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -51,7 +51,7 @@ APPS:
       weekends:
         - 08:00-19:00
 
-  - name: notify-delivery-worker-database-and-job-tasks
+  - name: notify-delivery-worker-jobs
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     threshold: 250
@@ -72,7 +72,7 @@ APPS:
     scalers: [SqsScaler]
     queues:  [notify-internal-tasks]
 
-  - name: notify-delivery-worker-letters-tasks
+  - name: notify-delivery-worker-letters
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
     threshold: 250

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -51,19 +51,33 @@ APPS:
       weekends:
         - 08:00-19:00
 
-  - name: notify-delivery-worker-database
+  - name: notify-delivery-worker-database-and-job-tasks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     threshold: 250
     scalers: [SqsScaler]
-    queues:  [database-tasks]
+    queues:  [database-tasks, job-tasks]
 
-  - name: notify-delivery-worker
+  - name: notify-delivery-worker-retry-tasks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
     threshold: 250
     scalers: [SqsScaler]
-    queues:  [notify-internal-tasks, retry-tasks, job-tasks, letter-tasks]
+    queues:  [retry-tasks]
+
+  - name: notify-delivery-worker-internal
+    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
+    threshold: 250
+    scalers: [SqsScaler]
+    queues:  [notify-internal-tasks]
+
+  - name: notify-delivery-worker-letters-tasks
+    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
+    threshold: 250
+    scalers: [SqsScaler]
+    queues:  [create-letters-pdf-tasks, letter-tasks]
 
   - name: notify-delivery-worker-research
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}


### PR DESCRIPTION
This is so that retry-tasks queue, which can have quite a lot of
load, has its own worker, and other queues are paired with queues
that flow similarly:

- letter-tasks with create-letters-pdf-tasks
- job-tasks with database-tasks

Pivotal ticket: https://www.pivotaltracker.com/story/show/165021462

Connected API PR: alphagov/notifications-api#2486
Connected AWS PR: alphagov/notifications-aws#512