### PR TITLE
Make scaling timezone-aware

### DIFF
--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -5,6 +5,7 @@ import os
 
 import psycopg2
 import boto3
+
 from app.utils import get_statsd_client
 
 
@@ -30,7 +31,7 @@ class BaseScaler:
 
     def _now(self):
         # to make mocking in tests easier
-        return datetime.now()
+        return datetime.utcnow()
 
     def get_desired_instance_count(self):
         raise NotImplementedError

--- a/app/schedule_scaler.py
+++ b/app/schedule_scaler.py
@@ -1,6 +1,8 @@
 import datetime
 import math
 
+import pytz
+
 from app.base_scalers import BaseScaler
 from app.config import config
 
@@ -22,6 +24,7 @@ class ScheduleScaler(BaseScaler):
             return False
 
         now = self._now()
+        now = pytz.utc.localize(now).astimezone(pytz.timezone("Europe/London")).replace(tzinfo=None)
         week_part = "workdays" if now.weekday() in range(5) else "weekends"  # Monday = 0, sunday = 6
 
         if week_part not in self.schedule:
@@ -29,9 +32,10 @@ class ScheduleScaler(BaseScaler):
 
         for time_range_string in self.schedule[week_part]:
             # convert the time range string to time objects
-            start, end = [datetime.datetime.strptime(i, '%H:%M').time() for i in time_range_string.split('-')]
+            start, end = [datetime.datetime.strptime(i, '%H:%M').time()
+                          for i in time_range_string.split('-')]
 
-            if datetime.datetime.combine(now, start) <= now <= datetime.datetime.combine(now, end):
+            if start <= now.time() <= end:
                 return True
 
         return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary==2.8.1
 pyyaml==5.1
 
 git+https://github.com/alphagov/notifications-utils.git@31.2.5#egg=notifications-utils==31.2.5
+pytz


### PR DESCRIPTION
Yesterday morning there was a spike on email traffic between 08:30 and
08:40 that were not delivered within 10 seconds. A quick investigation
showed that the autoscaler did not increase the number of instances
at 08:00 according to its schedule but, since we switched to BST, it
scales at 09:00 instead.

This commit addresses this inconsistency by using `pytz` to get
timezone-aware time objects.

`pytz` is a dependency of `notifications-utils` so in order to avoid
version clashes I'm just explicitly listing it as a dependency without
version.