### PR TITLE
Scale sooner and have more scheduled instances

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -28,11 +28,11 @@ APPS:
   - name: notify-api
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 1000
+    threshold: 800
     scalers: [ElbScaler, ScheduleScaler]
     elb_name: 'notify-paas-proxy'
     schedule:
-      scale_factor: 0.5
+      scale_factor: 0.6
       workdays:
         - 08:00-19:00
       weekends:


### PR DESCRIPTION
If the API is under pressure it may not respond to CF healthcheck within
1s. That will make CF kill the instance terminating any requests that
were in process or were waiting to be served.