### PR TITLE
Add template-preview specific instance count

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ preview:
 	@if [ -f data.yml ]; then rm data.yml; fi
 	@echo "---" >> data.yml
 	@echo "CF_SPACE: preview" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 1" >> data.yml
@@ -83,6 +84,7 @@ staging:
 	@if [ -f data.yml ]; then rm data.yml; fi
 	@echo "---" >> data.yml
 	@echo "CF_SPACE: staging" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
@@ -97,6 +99,7 @@ production:
 	@if [ -f data.yml ]; then rm data.yml; fi
 	@echo "---" >> data.yml
 	@echo "CF_SPACE: production" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
@@ -152,6 +155,7 @@ test: flake8
 	@if [ -f data.yml ]; then rm data.yml; fi
 	@echo "---" >> data.yml
 	@echo "CF_SPACE: test" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -115,7 +115,7 @@ APPS:
 
   - name: notify-template-preview
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    max_instances: {{ MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW }}
     threshold: 8
     scalers: [SqsScaler, ScheduledJobsScaler, ScheduleScaler]
     queues:  [create-letters-pdf-tasks, letter-tasks]


### PR DESCRIPTION
Set it to 40 on prod and to MAX_INSTANCE_COUNT_HIGH on the other
environments.

Template preview doesn't talk to the DB so we can scale it more
aggressively, only bound by our Org memory limit which we are using
about 25-30% of.