### PR TITLE
AUTO: Clean up scaler config

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,14 +2,12 @@ import app
 
 
 class App:
-    def __init__(self, name, scalers, **scaler_details):
+    def __init__(self, name, min_instances, max_instances, scalers):
         self.name = name
-        self.scaler_details = scaler_details
-        self.scaler_details['app_name'] = name
         self.scalers = []
         for scaler in scalers:
-            scaler_cls = getattr(app, scaler)
-            self.scalers.append(scaler_cls(**self.scaler_details))
+            scaler_cls = getattr(app, scaler['type'])
+            self.scalers.append(scaler_cls(name, min_instances, max_instances, **scaler))
 
     def query_scalers(self):
         desired_instance_counts = []

--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -38,10 +38,10 @@ class BaseScaler:
 
 
 class AwsBaseScaler(BaseScaler):
-    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+    def __init__(self, app_name, min_instances, max_instances, aws_region=None):
         super().__init__(app_name, min_instances, max_instances)
 
-        self.aws_region = kwargs.get('aws_region') or os.environ.get('AWS_REGION', 'eu-west-1')
+        self.aws_region = aws_region or os.environ.get('AWS_REGION', 'eu-west-1')
         self.aws_account_id = self._get_boto3_client('sts', region_name=self.aws_region).get_caller_identity()['Account']  # noqa
 
     def _get_boto3_client(self, client, **kwargs):
@@ -51,7 +51,7 @@ class AwsBaseScaler(BaseScaler):
 class DbQueryScaler(BaseScaler):
     DB_CONNECTION_TIMEOUT = timedelta(seconds=60)
 
-    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+    def __init__(self, app_name, min_instances, max_instances):
         super().__init__(app_name, min_instances, max_instances)
         self._init_db_uri()
         self.last_db_error = datetime.min

--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -17,7 +17,8 @@ class BaseScaler:
         self.app_name = kwargs.get('app_name', 'missing_name')
         self.statsd_client = get_statsd_client()
 
-    def normalize_desired_instance_count(self, desired_instances):
+    def get_desired_instance_count(self):
+        desired_instances = self._get_desired_instance_count()
         desired_instances = max(desired_instances, self.min_instances)
         desired_instances = min(desired_instances, self.max_instances)
 
@@ -33,7 +34,7 @@ class BaseScaler:
         # to make mocking in tests easier
         return datetime.utcnow()
 
-    def get_desired_instance_count(self):
+    def _get_desired_instance_count(self):
         raise NotImplementedError
 
 

--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -10,11 +10,10 @@ from app.utils import get_statsd_client
 
 
 class BaseScaler:
-    def __init__(self, min_instances, max_instances, threshold, **kwargs):
+    def __init__(self, app_name, min_instances, max_instances):
+        self.app_name = app_name
         self.min_instances = min_instances
         self.max_instances = max_instances
-        self.threshold = threshold
-        self.app_name = kwargs.get('app_name', 'missing_name')
         self.statsd_client = get_statsd_client()
 
     def get_desired_instance_count(self):
@@ -39,8 +38,8 @@ class BaseScaler:
 
 
 class AwsBaseScaler(BaseScaler):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances)
 
         self.aws_region = kwargs.get('aws_region') or os.environ.get('AWS_REGION', 'eu-west-1')
         self.aws_account_id = self._get_boto3_client('sts', region_name=self.aws_region).get_caller_identity()['Account']  # noqa
@@ -52,8 +51,8 @@ class AwsBaseScaler(BaseScaler):
 class DbQueryScaler(BaseScaler):
     DB_CONNECTION_TIMEOUT = timedelta(seconds=60)
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances)
         self._init_db_uri()
         self.last_db_error = datetime.min
 

--- a/app/elb_scaler.py
+++ b/app/elb_scaler.py
@@ -7,7 +7,7 @@ from app.base_scalers import AwsBaseScaler
 
 class ElbScaler(AwsBaseScaler):
     def __init__(self, app_name, min_instances, max_instances, **kwargs):
-        super().__init__(app_name, min_instances, max_instances, **kwargs)
+        super().__init__(app_name, min_instances, max_instances, kwargs.get('aws_region'))
         self.elb_name = kwargs['elb_name']
         self.threshold = kwargs['threshold']
         self.request_count_time_range = kwargs.get('request_count_time_range', {'minutes': 5})

--- a/app/elb_scaler.py
+++ b/app/elb_scaler.py
@@ -16,7 +16,7 @@ class ElbScaler(AwsBaseScaler):
         if self.cloudwatch_client is None:
             self.cloudwatch_client = super()._get_boto3_client('cloudwatch', region_name=self.aws_region)
 
-    def get_desired_instance_count(self):
+    def _get_desired_instance_count(self):
         logging.debug('Processing {}'.format(self.app_name))
         request_counts = self._get_request_counts()
         if len(request_counts) == 0:
@@ -29,7 +29,7 @@ class ElbScaler(AwsBaseScaler):
 
         self.gauge("{}.request-count".format(self.app_name), highest_request_count)
         desired_instance_count = int(math.ceil(highest_request_count / float(self.threshold)))
-        return self.normalize_desired_instance_count(desired_instance_count)
+        return desired_instance_count
 
     def _get_request_counts(self):
         self._init_cloudwatch_client()

--- a/app/elb_scaler.py
+++ b/app/elb_scaler.py
@@ -6,9 +6,10 @@ from app.base_scalers import AwsBaseScaler
 
 
 class ElbScaler(AwsBaseScaler):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances, **kwargs)
         self.elb_name = kwargs['elb_name']
+        self.threshold = kwargs['threshold']
         self.request_count_time_range = kwargs.get('request_count_time_range', {'minutes': 5})
         self.cloudwatch_client = None
 

--- a/app/schedule_scaler.py
+++ b/app/schedule_scaler.py
@@ -13,11 +13,11 @@ class ScheduleScaler(BaseScaler):
         self.schedule = kwargs['schedule']
         self.scale_factor = self.schedule.get('scale_factor') or config['SCALERS']['DEFAULT_SCHEDULE_SCALE_FACTOR']
 
-    def get_desired_instance_count(self):
+    def _get_desired_instance_count(self):
         if not self._should_scale_on_schedule():
             return self.min_instances
 
-        return self.normalize_desired_instance_count(int(math.ceil(self.max_instances * self.scale_factor)))
+        return int(math.ceil(self.max_instances * self.scale_factor))
 
     def _should_scale_on_schedule(self):
         if not config['SCALERS']['SCHEDULE_SCALER_ENABLED']:

--- a/app/schedule_scaler.py
+++ b/app/schedule_scaler.py
@@ -8,8 +8,8 @@ from app.config import config
 
 
 class ScheduleScaler(BaseScaler):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances)
         self.schedule = kwargs['schedule']
         self.scale_factor = self.schedule.get('scale_factor') or config['SCALERS']['DEFAULT_SCHEDULE_SCALE_FACTOR']
 

--- a/app/scheduled_jobs_scaler.py
+++ b/app/scheduled_jobs_scaler.py
@@ -8,7 +8,8 @@ class ScheduledJobsScaler(DbQueryScaler):
     # use only a third of the items because not everything gets put on the queue at once
     scheduled_items_factor = 0.3
 
-    def __init__(self, **kwargs):
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances, **kwargs)
         # Use coalesce to avoid null values when nothing is scheduled
         # https://stackoverflow.com/a/6530371/1477072
         query = """
@@ -18,8 +19,7 @@ class ScheduledJobsScaler(DbQueryScaler):
         job_status = 'scheduled';
         """
         self.query = query.format(self.scheduled_job_lookahead)
-
-        super().__init__(**kwargs)
+        self.threshold = kwargs['threshold']
 
     def _get_desired_instance_count(self):
         scheduled_items = self.run_query()

--- a/app/scheduled_jobs_scaler.py
+++ b/app/scheduled_jobs_scaler.py
@@ -9,7 +9,7 @@ class ScheduledJobsScaler(DbQueryScaler):
     scheduled_items_factor = 0.3
 
     def __init__(self, app_name, min_instances, max_instances, **kwargs):
-        super().__init__(app_name, min_instances, max_instances, **kwargs)
+        super().__init__(app_name, min_instances, max_instances)
         # Use coalesce to avoid null values when nothing is scheduled
         # https://stackoverflow.com/a/6530371/1477072
         query = """

--- a/app/scheduled_jobs_scaler.py
+++ b/app/scheduled_jobs_scaler.py
@@ -21,8 +21,8 @@ class ScheduledJobsScaler(DbQueryScaler):
 
         super().__init__(**kwargs)
 
-    def get_desired_instance_count(self):
+    def _get_desired_instance_count(self):
         scheduled_items = self.run_query()
         scale_items = scheduled_items * self.scheduled_items_factor
         desired_instance_count = int(math.ceil(scale_items / float(self.threshold)))
-        return self.normalize_desired_instance_count(desired_instance_count)
+        return desired_instance_count

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -7,7 +7,7 @@ from app.config import config
 
 class SqsScaler(AwsBaseScaler):
     def __init__(self, app_name, min_instances, max_instances, **kwargs):
-        super().__init__(app_name, min_instances, max_instances, **kwargs)
+        super().__init__(app_name, min_instances, max_instances, kwargs.get('aws_region'))
         self.threshold = kwargs['threshold']
         self.queues = kwargs['queues'] if isinstance(kwargs['queues'], list) else [kwargs['queues']]
         self.sqs_queue_prefix = config['SCALERS']['SQS_QUEUE_PREFIX']

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -6,8 +6,9 @@ from app.config import config
 
 
 class SqsScaler(AwsBaseScaler):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, app_name, min_instances, max_instances, **kwargs):
+        super().__init__(app_name, min_instances, max_instances, **kwargs)
+        self.threshold = kwargs['threshold']
         self.queues = kwargs['queues'] if isinstance(kwargs['queues'], list) else [kwargs['queues']]
         self.sqs_queue_prefix = config['SCALERS']['SQS_QUEUE_PREFIX']
         self.sqs_client = None

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -16,13 +16,13 @@ class SqsScaler(AwsBaseScaler):
         if self.sqs_client is None:
             self.sqs_client = super()._get_boto3_client('sqs', region_name=self.aws_region)
 
-    def get_desired_instance_count(self):
+    def _get_desired_instance_count(self):
         logging.debug('Processing {}'.format(self.app_name))
         total_message_count = self._get_total_message_count(self.queues)
         logging.debug('Total message count: {}'.format(total_message_count))
         desired_instance_count = int(math.ceil(total_message_count / float(self.threshold)))
 
-        return self.normalize_desired_instance_count(desired_instance_count)
+        return desired_instance_count
 
     def _get_sqs_queue_name(self, name):
         return "{}{}".format(self.sqs_queue_prefix, name)

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -28,114 +28,137 @@ APPS:
   - name: notify-api
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 800
-    scalers: [ElbScaler, ScheduleScaler]
-    elb_name: 'notify-paas-proxy'
-    schedule:
-      scale_factor: 0.6
-      workdays:
-        - 08:00-19:00
-      weekends:
-        - 09:00-17:00
+    scalers:
+      - type: ElbScaler
+        elb_name: 'notify-paas-proxy'
+        threshold: 800
+      - type: ScheduleScaler
+        schedule:
+          scale_factor: 0.6
+          workdays:
+            - 08:00-19:00
+          weekends:
+            - 09:00-17:00
 
   - name: notify-delivery-worker-sender
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 600
-    scalers: [SqsScaler, ScheduleScaler, ScheduledJobsScaler]
-    queues: [send-sms-tasks, send-email-tasks]
-    schedule:
-      scale_factor: 0.4
-      workdays:
-        - 08:00-19:00
-      weekends:
-        - 08:00-19:00
+    scalers:
+      - type: ScheduledJobsScaler
+        threshold: 600
+      - type: SqsScaler
+        queues: [send-sms-tasks, send-email-tasks]
+        threshold: 600
+      - type: ScheduleScaler
+        schedule:
+          scale_factor: 0.4
+          workdays:
+            - 08:00-19:00
+          weekends:
+            - 08:00-19:00
 
   - name: notify-delivery-worker-jobs
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [database-tasks, job-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [database-tasks, job-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-retry-tasks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [retry-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [retry-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-internal
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [notify-internal-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [notify-internal-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-letters
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [create-letters-pdf-tasks, letter-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [create-letters-pdf-tasks, letter-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-research
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [research-mode-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [research-mode-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-priority
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [priority-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [priority-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-periodic
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 250
-    scalers: [SqsScaler]
-    queues:  [periodic-tasks, statistics-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [periodic-tasks, statistics-tasks]
+        threshold: 250
 
   - name: notify-delivery-worker-receipts
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
-    threshold: 250
-    scalers: [SqsScaler, ScheduleScaler]
-    queues:  [ses-callbacks]
-    schedule:
-      scale_factor: 0.3
-      workdays:
-        - 08:00-19:00
-      weekends:
-        - 08:00-19:00
+    scalers:
+      - type: SqsScaler
+        queues:  [ses-callbacks]
+        threshold: 250
+      - type: ScheduleScaler
+        schedule:
+          scale_factor: 0.3
+          workdays:
+            - 08:00-19:00
+          weekends:
+            - 08:00-19:00
 
   - name: notify-template-preview
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW }}
-    threshold: 8
-    scalers: [SqsScaler, ScheduledJobsScaler, ScheduleScaler]
-    queues:  [create-letters-pdf-tasks, letter-tasks]
-    schedule:
-      scale_factor: 0.4
-      workdays:
-        - 08:00-19:00
-      weekends:
-        - 08:00-19:00
+    scalers:
+      - type: ScheduledJobsScaler
+        threshold: 8
+      - type: SqsScaler
+        queues:  [create-letters-pdf-tasks, letter-tasks]
+        threshold: 8
+      - type: ScheduleScaler
+        schedule:
+          scale_factor: 0.4
+          workdays:
+            - 08:00-19:00
+          weekends:
+            - 08:00-19:00
 
   - name: notify-delivery-worker-service-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 500
-    scalers: [SqsScaler, ScheduledJobsScaler]
-    queues:  [service-callbacks]
+    scalers:
+      - type: ScheduledJobsScaler
+        threshold: 8
+      - type: SqsScaler
+        queues:  [service-callbacks]
+        threshold: 500
 
   - name: notify-antivirus
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    threshold: 50
-    scalers: [SqsScaler]
-    queues:  [antivirus-tasks]
+    scalers:
+      - type: SqsScaler
+        queues:  [antivirus-tasks]
+        threshold: 50

--- a/tests/test_base_scalers.py
+++ b/tests/test_base_scalers.py
@@ -9,21 +9,18 @@ from freezegun import freeze_time
 
 from app.base_scalers import BaseScaler, AwsBaseScaler, DbQueryScaler
 
-INPUT_ATTRS = {
-    'min_instances': 1,
-    'max_instances': 2,
-    'threshold': 1500,
-}
+app_name = 'test-app'
+min_instances = 1
+max_instances = 2
 
 
 class TestBaseScaler:
     def test_init_assigns_basic_values(self):
-        input_attrs = dict(INPUT_ATTRS, **{'extra_field_1': 'some_value'})
-        base_scaler = BaseScaler(**input_attrs)
+        base_scaler = BaseScaler(app_name, min_instances, max_instances)
 
-        assert base_scaler.min_instances == input_attrs['min_instances']
-        assert base_scaler.max_instances == input_attrs['max_instances']
-        assert base_scaler.threshold == input_attrs['threshold']
+        assert base_scaler.app_name == app_name
+        assert base_scaler.min_instances == min_instances
+        assert base_scaler.max_instances == max_instances
 
     @pytest.mark.parametrize('min_instances,max_instances,desired_instances,expected_instances', [
         (3, 5, 4, 4),
@@ -36,50 +33,44 @@ class TestBaseScaler:
         "Desired below lower limit",
         "Desired negative",
     ])
-    def test_normalize_desired_instance_count(
+    def test_get_desired_instance_count_is_normalized(
             self, min_instances, max_instances, desired_instances, expected_instances):
 
-        input_attrs = {
-            'min_instances': min_instances,
-            'max_instances': max_instances,
-            'threshold': 1500,
-            'extra_field_1': 'some_value'
-        }
-        base_scaler = BaseScaler(**input_attrs)
-
-        assert base_scaler.normalize_desired_instance_count(desired_instances) == expected_instances
+        base_scaler = BaseScaler(app_name, min_instances, max_instances)
+        with patch.object(base_scaler, '_get_desired_instance_count', side_effect=[desired_instances]):
+            assert base_scaler.get_desired_instance_count() == expected_instances
 
 
 @patch('app.base_scalers.boto3')
 class TestAwsBaseScaler:
     def test_init_assigns_basic_values(self, mock_boto3):
-        input_attrs = dict(INPUT_ATTRS, **{'aws_region': 'eu-west-1'})
-        aws_base_scaler = AwsBaseScaler(**input_attrs)
+        input_attrs = {'aws_region': 'eu-west-1'}
+        aws_base_scaler = AwsBaseScaler(app_name, min_instances, max_instances, **input_attrs)
 
-        assert aws_base_scaler.min_instances == input_attrs['min_instances']
-        assert aws_base_scaler.max_instances == input_attrs['max_instances']
-        assert aws_base_scaler.threshold == input_attrs['threshold']
+        assert aws_base_scaler.app_name == app_name
+        assert aws_base_scaler.min_instances == min_instances
+        assert aws_base_scaler.max_instances == max_instances
 
     def test_aws_credentials_from_attributes(self, mock_boto3):
-        input_attrs = dict(INPUT_ATTRS, **{'aws_region': 'eu-west-1'})
-        aws_base_scaler = AwsBaseScaler(**input_attrs)
+        input_attrs = {'aws_region': 'eu-west-1'}
+        aws_base_scaler = AwsBaseScaler(app_name, min_instances, max_instances, **input_attrs)
 
         assert aws_base_scaler.aws_region == input_attrs['aws_region']
 
     def test_aws_credentials_from_env_var(self, mock_boto3):
         with patch.dict(os.environ, {'AWS_REGION': 'us-west-1'}):
-            aws_base_scaler = AwsBaseScaler(**INPUT_ATTRS)
+            aws_base_scaler = AwsBaseScaler(app_name, min_instances, max_instances)
             assert aws_base_scaler.aws_region == 'us-west-1'
 
     def test_aws_credentials_default_value(self, mock_boto3):
-        aws_base_scaler = AwsBaseScaler(**INPUT_ATTRS)
+        aws_base_scaler = AwsBaseScaler(app_name, min_instances, max_instances)
         assert aws_base_scaler.aws_region == 'eu-west-1'
 
     def test_aws_account_id_from_boto_client(self, mock_boto3):
         mock_client = mock_boto3.client
         mock_client.return_value.get_caller_identity.return_value = {'Account': 123456}
 
-        aws_base_scaler = AwsBaseScaler(**INPUT_ATTRS)
+        aws_base_scaler = AwsBaseScaler(app_name, min_instances, max_instances)
         assert aws_base_scaler.aws_region == 'eu-west-1'
         assert aws_base_scaler.aws_account_id == 123456
         mock_client.assert_called_with('sts', region_name='eu-west-1')
@@ -96,7 +87,7 @@ class TestDbQueryScaler:
     def setup_method(self, method):
         vcap_string = json.dumps({'postgres': [{'credentials': {'uri': 'test-db-uri'}}]})
         with patch.dict(os.environ, {'VCAP_SERVICES': vcap_string}):
-            self.db_query_scaler = DbQueryScaler(**INPUT_ATTRS)
+            self.db_query_scaler = DbQueryScaler(app_name, min_instances, max_instances)
             self.db_query_scaler.query = 'foo'
 
     def test_db_uri_is_loaded(self):

--- a/tests/test_scheduled_jobs_scaler.py
+++ b/tests/test_scheduled_jobs_scaler.py
@@ -2,18 +2,21 @@ from unittest.mock import Mock
 
 from app.scheduled_jobs_scaler import ScheduledJobsScaler
 
+app_name = 'test-app'
+min_instances = 1
+max_instances = 5
+
 
 class TestScheduledJobsScaler:
     def test_init_assigns_basic_values(self):
         input_attrs = {
-            'min_instances': 1,
-            'max_instances': 2,
             'threshold': 1500,
         }
-        scheduled_job_scaler = ScheduledJobsScaler(**input_attrs)
+        scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
 
-        assert scheduled_job_scaler.min_instances == input_attrs['min_instances']
-        assert scheduled_job_scaler.max_instances == input_attrs['max_instances']
+        assert scheduled_job_scaler.app_name == app_name
+        assert scheduled_job_scaler.min_instances == min_instances
+        assert scheduled_job_scaler.max_instances == max_instances
         assert scheduled_job_scaler.threshold == input_attrs['threshold']
         assert scheduled_job_scaler.query == """
         SELECT COALESCE(SUM(notification_count), 0)
@@ -24,11 +27,9 @@ class TestScheduledJobsScaler:
 
     def test_get_desired_instance_count(self):
         input_attrs = {
-            'min_instances': 1,
-            'max_instances': 5,
             'threshold': 1500,
         }
-        scheduled_job_scaler = ScheduledJobsScaler(**input_attrs)
+        scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
         scheduled_job_scaler.run_query = Mock(return_value=10000)
 
         # 10k items * 0.3 = 3k => 2 instances

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -2,34 +2,37 @@ from unittest.mock import patch, Mock, call
 
 from app.sqs_scaler import SqsScaler
 
+app_name = 'test-app'
+min_instances = 1
+max_instances = 2
+
 
 @patch('app.base_scalers.boto3')
 class TestSqsScaler:
     input_attrs = {
-        'min_instances': 1,
-        'max_instances': 2,
         'threshold': 250,
     }
 
     def test_init_assigns_relevant_values(self, mock_boto3):
         self.input_attrs['queues'] = ['queue1', 'queue2']
-        sqs_scaler = SqsScaler(**self.input_attrs)
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        assert sqs_scaler.min_instances == self.input_attrs['min_instances']
-        assert sqs_scaler.max_instances == self.input_attrs['max_instances']
+        assert sqs_scaler.app_name == app_name
+        assert sqs_scaler.min_instances == min_instances
+        assert sqs_scaler.max_instances == max_instances
         assert sqs_scaler.threshold == self.input_attrs['threshold']
         assert sqs_scaler.queues == self.input_attrs['queues']
 
     def test_init_assigns_relevant_values_non_list_queue(self, mock_boto3):
         self.input_attrs['queues'] = 'queue1'
-        sqs_scaler = SqsScaler(**self.input_attrs)
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
         assert sqs_scaler.queues == ['queue1']
 
     def test_sqs_client_initialization(self, mock_boto3):
         self.input_attrs['queues'] = ['queue1', 'queue2']
         mock_client = mock_boto3.client
-        sqs_scaler = SqsScaler(**self.input_attrs)
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
         sqs_scaler.statsd_client = Mock()
 
         assert sqs_scaler.sqs_client is None
@@ -46,7 +49,7 @@ class TestSqsScaler:
             {'Attributes': {'ApproximateNumberOfMessages': '350'}},
         ]
 
-        sqs_scaler = SqsScaler(**self.input_attrs)
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
         sqs_scaler.statsd_client = Mock()
         assert sqs_scaler.get_desired_instance_count() == 2
         calls = [


### PR DESCRIPTION
- The config was a bit confusing for the scalers as we were just passing in the whole of app as kwargs
- Scope down scaler config to that particular scaler
- Allows individual configuration of scalers and in theory we could do stuff like have 2 of the same scaler on an app with different thresholds/schedules etc.