### PR TITLE
make template preview scale based on retry queues

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -130,13 +130,13 @@ APPS:
             - 08:00-19:00
 
   - name: notify-template-preview
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW }}
     scalers:
       - type: ScheduledJobsScaler
         threshold: 8
       - type: SqsScaler
-        queues:  [create-letters-pdf-tasks, letter-tasks]
+        queues:  [create-letters-pdf-tasks, letter-tasks, retry-tasks]
         threshold: 8
       - type: ScheduleScaler
         schedule:


### PR DESCRIPTION
also bump minimum instances from 2 to 4

template preview takes traffic from:
* admin app
* create-letters-pdf-tasks queue (creating pdfs for templated letters)
* letter-tasks queue (sanitising precompiled pdfs in process-virus-scan-passed)
* retry queue (if either of the tasks above fails, they're retried)

we should scale from all three queues, as we saw issues where the app crashed, so tasks failed, so they were put on the retry queue, and the app didn't scale up despite the retry queue growing and growing