### PR TITLE
Bump utils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ cloudfoundry-client==1.4.0
 psycopg2-binary==2.8.1
 pyyaml==5.1
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.7#egg=notifications-utils==33.2.7
+git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
 pytz


### PR DESCRIPTION
This brings in a fix for the error handling: alphagov/notifications-utils#640