### PR TITLE
Set max number of API instances to 25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ preview:
 	@echo "CF_SPACE: preview" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 1" >> data.yml
@@ -88,6 +90,8 @@ staging:
 	@echo "CF_SPACE: staging" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
@@ -104,6 +108,8 @@ production:
 	@echo "CF_SPACE: production" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
@@ -160,6 +166,8 @@ test: flake8
 	@echo "CF_SPACE: test" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -27,8 +27,8 @@ SCALERS:
 
 APPS:
   - name: notify-api
-    min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    min_instances: {{ MIN_INSTANCE_COUNT_API }}
+    max_instances: {{ MAX_INSTANCE_COUNT_API }}
     scalers:
       - type: ElbScaler
         elb_name: 'notify-paas-proxy'


### PR DESCRIPTION
We add a new variable to do this as we don't need to scale the
workers that high too.

This was based on an incident today of a group of 502s and we
believe increasing the number of APIs may help address similar
traffic spikes in the future however as we never got down to the
root cause we are mostly hoping this change will be beneficial.