### PR TITLE
Increase max instance count for callback app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ preview:
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 1" >> data.yml
@@ -94,6 +95,7 @@ staging:
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
@@ -111,6 +113,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
@@ -170,6 +173,7 @@ test: flake8
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -156,7 +156,7 @@ APPS:
 
   - name: notify-delivery-worker-service-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
+    max_instances: {{ MAX_INSTANCE_COUNT_CALLBACK }}
     scalers:
       - type: ScheduledJobsScaler
         threshold: 8


### PR DESCRIPTION
 Increase the number of max instances for service status callbacks from 5 to 7.

We'd like to delivery the notification status updates faster than we are. We find that this queue can back up when we have a lot of callbacks to send. We are going increase the max instance count gradually so that the GOV.UK email team can monitor it.  This is the first bump. 