### PR TITLE
Add template preview celery

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -154,6 +154,14 @@ APPS:
           weekends:
             - 08:00-19:00
 
+  - name: notify-template-preview-celery
+    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    scalers:
+      - type: SqsScaler
+        queues:  [antivirus-tasks, letter-tasks, sanitise-letter-tasks]
+        threshold: 100
+
   - name: notify-delivery-worker-service-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_CALLBACK }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-boto3==1.9.134
-cloudfoundry-client==1.4.0
-psycopg2-binary==2.8.1
-pyyaml==5.1
-redis==3.3.7
+boto3==1.10.38
+cloudfoundry-client==1.10.0
+psycopg2-binary==2.8.4
+pyyaml==5.3
+redis==3.4.1
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.9#egg=notifications-utils==33.2.9
+git+https://github.com/alphagov/notifications-utils.git@36.6.1#egg=notifications-utils==36.6.1
 pytz

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,10 +1,10 @@
-fakeredis==1.0.4
-flake8==3.7.7
-freezegun==0.3.11
-jinja2-cli[yaml]==0.6.0
-pytest-cov==2.6.1
-pytest-mock==1.10.4
-pytest-randomly==3.0.0
-pytest==4.4.1
+fakeredis==1.2.1
+flake8==3.7.9
+freezegun==0.3.15
+jinja2-cli[yaml]==0.7.0
+pytest-cov==2.8.1
+pytest-mock==2.0.0
+pytest-randomly==3.2.1
+pytest==5.3.5
 
 -r requirements.txt


### PR DESCRIPTION
This will give us between 2 and 10 instances in production, scaling on
the template-preview queue (`sanitise-letter-tasks`) and on the two
queues that precompiled letters pass through before being put on the
template preview queue.

The delivery apps typically have a threshold for the SqsScaler of 250
and 11 workers. Template preview celery has 5 workers and its task takes
a little longer to run, so the threshold for scaling has been made
lower.