### PR TITLE
Increase max instances for Template Preview Celery

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -156,7 +156,7 @@ APPS:
 
   - name: notify-template-preview-celery
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     scalers:
       - type: SqsScaler
         queues:  [antivirus-tasks, letter-tasks, sanitise-letter-tasks]


### PR DESCRIPTION
The max instances in production was 10 but has been increased to 20.
The app is not running in production yet, so this change is to increase
the number of instances just to be on the safe side - the number can be
lowered once we've seen how many it needs.