### PR TITLE
Double the number if initial instances for template-preview-celery.

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -155,7 +155,7 @@ APPS:
             - 08:00-19:00
 
   - name: notify-template-preview-celery
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     scalers:
       - type: SqsScaler


### PR DESCRIPTION
Production only starts with 2 instances, bumping that up to 4. 
Should consider lowering the number of messages in the queue before scaling as well. 