### PR TITLE
Increase min api instance count on prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ production:
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml


### PR DESCRIPTION
We are experiencing a lot of queue pool exceptions.
Initial reaction to ease this problem is to increase the min api instance count.
A deeper investigation to the problem will follow.