### PR TITLE
Add queue to SqsScaler for delivery-worker-receipts app

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -127,7 +127,7 @@ APPS:
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     scalers:
       - type: SqsScaler
-        queues:  [ses-callbacks]
+        queues:  [ses-callbacks,sms-callbacks]
         threshold: 250
       - type: ScheduleScaler
         schedule:


### PR DESCRIPTION
The `delivery-worker-receipts` app will now listen to a new queue, `sms-callbacks`.

https://www.pivotaltracker.com/story/show/171791142