### PR TITLE
Up api instances to 24 minimum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ production:
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_API: 18" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 24" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 10" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml


### PR DESCRIPTION
We are seeing queue pool exceptions and think there is little risk but
potentially some benefit of running more api instances. This will bump
up to 24 at a minimum. It may be overscaled but better safe than sorry.