### PR TITLE
Bumping instances to 30 for the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ production:
 	@echo "CF_SPACE: production" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 30" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 24" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 10" >> data.yml


### PR DESCRIPTION
Think this should help with slow response times on API
Aware we are pushing the theoretical limits of the DB connections but in
reality we are still far off our max of 5000.