### PR TITLE
change requests per app instance per minute from 800 to 600

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -32,7 +32,7 @@ APPS:
     scalers:
       - type: ElbScaler
         elb_name: 'notify-paas-proxy'
-        threshold: 800
+        threshold: 600
       - type: ScheduleScaler
         schedule:
           scale_factor: 0.6


### PR DESCRIPTION
the autoscaler is setting the app to, for example, 24 instances for 19000 requests per minute. We're still seeing slow requests, queue pools, etc, so we're trying lowering that limit 

For the same 19000 requests, the autoscaler will now scale to 32 instances

in practice we won't scale to 32 as our max is 30