### PR TITLE
Run the API at 35 instances always

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ production:
 	@echo "CF_SPACE: production" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_API: 30" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_API: 24" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 10" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml


### PR DESCRIPTION
We don't care about money at the moment as we are prioritising
reliabillity and not waking people up at night.

We think we can handle the DB connection increase (we've never gone
above 3.7k in production and can handle 5k). This should hopefully only
help us handle big spikes in traffic.