### PR TITLE
Bump the max instance count for service-callbacks to 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_CALLBACK: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 15" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml


### PR DESCRIPTION
With increased volumes lets try to get through the service-calback queue a bit faster