### PR TITLE
Scale based on queue throughput as well as queue length

### DIFF
--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -96,6 +96,7 @@ class SqsScaler(AwsBaseScaler):
             Unit='Count'
         )
         datapoints = result['Datapoints']
+        datapoints = sorted(datapoints, key=lambda x: x['Timestamp'])
         return [row['Sum'] for row in datapoints]
 
     def _get_throughput(self, queue):
@@ -110,7 +111,7 @@ class SqsScaler(AwsBaseScaler):
         highest_throughput = max(past_5_mins_of_throughput)
         logging.debug('Highest queue throughput: {}'.format(highest_throughput))
 
-        self.gauge("{}.queue-throughput".format(queue_name), highest_throughput)
+        self.gauge("{}.queue-throughput".format(queue_name), past_5_mins_of_throughput[-1])
         return highest_throughput
 
     def _get_total_throughput(self, queues):

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -5,11 +5,16 @@ from datetime import timedelta
 from app.base_scalers import AwsBaseScaler
 from app.config import config
 
+# calculated by looking at log output of a single instance of delivery-worker-save-api-notifications on production
+# during high load
+THROUGHPUT_OF_TASKS_PER_WORKER_PER_MINUTE = 1000
+
 
 class SqsScaler(AwsBaseScaler):
     def __init__(self, app_name, min_instances, max_instances, **kwargs):
         super().__init__(app_name, min_instances, max_instances, kwargs.get('aws_region'))
-        self.threshold = kwargs['threshold']
+        self.queue_length_threshold = kwargs['threshold']
+        self.throughput_threshold = THROUGHPUT_OF_TASKS_PER_WORKER_PER_MINUTE
         self.queues = kwargs['queues'] if isinstance(kwargs['queues'], list) else [kwargs['queues']]
         self.sqs_queue_prefix = config['SCALERS']['SQS_QUEUE_PREFIX']
         self.request_count_time_range = kwargs.get('request_count_time_range', {'minutes': 5})
@@ -36,13 +41,13 @@ class SqsScaler(AwsBaseScaler):
     def _get_desired_instance_count_based_on_current_queue_length(self):
         total_message_count = self._get_total_message_count(self.queues)
         logging.debug('Total message count: {}'.format(total_message_count))
-        desired_instance_count = int(math.ceil(total_message_count / float(self.threshold)))
+        desired_instance_count = int(math.ceil(total_message_count / float(self.queue_length_threshold)))
         return desired_instance_count
 
     def _get_desired_instance_count_based_on_queue_throughput(self):
         total_throughput = self._get_total_throughput(self.queues)
         logging.debug('Total throughput: {}'.format(total_throughput))
-        desired_instance_count = int(math.ceil(total_throughput / float(self.threshold)))
+        desired_instance_count = int(math.ceil(total_throughput / float(self.throughput_threshold)))
         return desired_instance_count
 
     def _get_sqs_queue_name(self, name):

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from datetime import timedelta
 
 from app.base_scalers import AwsBaseScaler
 from app.config import config
@@ -11,18 +12,37 @@ class SqsScaler(AwsBaseScaler):
         self.threshold = kwargs['threshold']
         self.queues = kwargs['queues'] if isinstance(kwargs['queues'], list) else [kwargs['queues']]
         self.sqs_queue_prefix = config['SCALERS']['SQS_QUEUE_PREFIX']
+        self.request_count_time_range = kwargs.get('request_count_time_range', {'minutes': 5})
         self.sqs_client = None
+        self.cloudwatch_client = None
 
     def _init_sqs_client(self):
         if self.sqs_client is None:
             self.sqs_client = super()._get_boto3_client('sqs', region_name=self.aws_region)
 
+    def _init_cloudwatch_client(self):
+        if self.cloudwatch_client is None:
+            self.cloudwatch_client = super()._get_boto3_client('cloudwatch', region_name=self.aws_region)
+
     def _get_desired_instance_count(self):
         logging.debug('Processing {}'.format(self.app_name))
+        desired_instance_count_throughput = self._get_desired_instance_count_based_on_queue_throughput()
+        desired_instance_count_queue_length = self._get_desired_instance_count_based_on_current_queue_length()
+        # How many instances we run should be enough to handle the current level of throughput, however
+        # if the throughput remains the same and we already have items building up in our queue, then we
+        # wish to scale even higher to bring the queue down
+        return desired_instance_count_throughput + desired_instance_count_queue_length
+
+    def _get_desired_instance_count_based_on_current_queue_length(self):
         total_message_count = self._get_total_message_count(self.queues)
         logging.debug('Total message count: {}'.format(total_message_count))
         desired_instance_count = int(math.ceil(total_message_count / float(self.threshold)))
+        return desired_instance_count
 
+    def _get_desired_instance_count_based_on_queue_throughput(self):
+        total_throughput = self._get_total_throughput(self.queues)
+        logging.debug('Total throughput: {}'.format(total_throughput))
+        desired_instance_count = int(math.ceil(total_throughput / float(self.threshold)))
         return desired_instance_count
 
     def _get_sqs_queue_name(self, name):
@@ -33,6 +53,7 @@ class SqsScaler(AwsBaseScaler):
             self.aws_region, self.aws_account_id, name)
 
     def _get_sqs_message_count(self, name):
+        # Number of visible messages waiting in the queue to be picked up
         self._init_sqs_client()
         response = self.sqs_client.get_queue_attributes(
             QueueUrl=self._get_sqs_queue_url(name),
@@ -49,3 +70,43 @@ class SqsScaler(AwsBaseScaler):
 
     def _get_total_message_count(self, queues):
         return sum(self._get_message_count(queue) for queue in queues)
+
+    def _get_sqs_throughput(self, name):
+        self._init_cloudwatch_client()
+        start_time = self._now() - timedelta(**self.request_count_time_range)
+        end_time = self._now()
+        result = self.cloudwatch_client.get_metric_statistics(
+            Namespace='AWS/SQS',
+            MetricName='NumberOfMessagesReceived',
+            Dimensions=[
+                {
+                    'Name': 'QueueName',
+                    'Value': name
+                },
+            ],
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=60,
+            Statistics=['Sum'],
+            Unit='Count'
+        )
+        datapoints = result['Datapoints']
+        return [row['Sum'] for row in datapoints]
+
+    def _get_throughput(self, queue):
+        queue_name = self._get_sqs_queue_name(queue)
+        past_5_mins_of_throughput = self._get_sqs_throughput(queue_name)
+
+        if len(past_5_mins_of_throughput) == 0:
+            past_5_mins_of_throughput = [0]
+        logging.debug('Queue throughput: {}'.format(past_5_mins_of_throughput))
+
+        # Keep the highest throughput over the specified time range
+        highest_throughput = max(past_5_mins_of_throughput)
+        logging.debug('Highest queue throughput: {}'.format(highest_throughput))
+
+        self.gauge("{}.queue-throughput".format(queue_name), highest_throughput)
+        return highest_throughput
+
+    def _get_total_throughput(self, queues):
+        return sum(self._get_throughput(queue) for queue in queues)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 from app.autoscaler import Autoscaler
 
 logging.basicConfig(
-    level=logging.WARNING,
+    level=logging.DEBUG,
     handlers=[
         logging.FileHandler('/home/vcap/logs/app.log'),
         logging.StreamHandler(sys.stdout),

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 from app.autoscaler import Autoscaler
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.WARNING,
     handlers=[
         logging.FileHandler('/home/vcap/logs/app.log'),
         logging.StreamHandler(sys.stdout),

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -107,7 +107,7 @@ class TestSqsScaler:
 
         assert sqs_scaler._get_throughput('my-queue') == 200
         # queue prefix "test" pulled from SQS_QUEUE_PREFIX env var
-        statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 200)
+        statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 50)
         _get_sqs_throughput_mock.assert_called_once_with('testmy-queue')
 
     def test_get_throughput_returns_0_if_no_data(self, mock_boto3, mocker):

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -24,7 +24,8 @@ class TestSqsScaler:
         assert sqs_scaler.app_name == app_name
         assert sqs_scaler.min_instances == min_instances
         assert sqs_scaler.max_instances == max_instances
-        assert sqs_scaler.threshold == self.input_attrs['threshold']
+        assert sqs_scaler.queue_length_threshold == self.input_attrs['threshold']
+        assert sqs_scaler.throughput_threshold == 1000
         assert sqs_scaler.queues == self.input_attrs['queues']
 
     def test_init_assigns_relevant_values_non_list_queue(self, mock_boto3):
@@ -88,9 +89,9 @@ class TestSqsScaler:
 
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        _get_throughput_mock = mocker.patch.object(sqs_scaler, '_get_throughput', side_effect=[200, 400])
+        _get_throughput_mock = mocker.patch.object(sqs_scaler, '_get_throughput', side_effect=[2000, 800])
 
-        # threshold is 250
+        # threshold is 1000
         assert sqs_scaler._get_desired_instance_count_based_on_queue_throughput() == 3
 
         assert _get_throughput_mock.call_args_list == [

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from freezegun import freeze_time
 from unittest.mock import patch, Mock, call
 
 from app.sqs_scaler import SqsScaler
@@ -11,6 +14,7 @@ max_instances = 2
 class TestSqsScaler:
     input_attrs = {
         'threshold': 250,
+        'queues': []
     }
 
     def test_init_assigns_relevant_values(self, mock_boto3):
@@ -29,18 +33,25 @@ class TestSqsScaler:
 
         assert sqs_scaler.queues == ['queue1']
 
-    def test_sqs_client_initialization(self, mock_boto3):
+    def test_client_initialization(self, mock_boto3):
         self.input_attrs['queues'] = ['queue1', 'queue2']
         mock_client = mock_boto3.client
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
         sqs_scaler.statsd_client = Mock()
 
         assert sqs_scaler.sqs_client is None
+        assert sqs_scaler.cloudwatch_client is None
         sqs_scaler.get_desired_instance_count()
         assert sqs_scaler.sqs_client == mock_client.return_value
-        mock_client.assert_called_with('sqs', region_name='eu-west-1')
+        assert sqs_scaler.cloudwatch_client == mock_client.return_value
+        calls = [
+            call('sqs', region_name='eu-west-1'),
+            call('cloudwatch', region_name='eu-west-1'),
+        ]
+        for x in calls:
+            assert x in mock_client.call_args_list
 
-    def test_get_desired_instance_count(self, mock_boto3):
+    def test_get_desired_instance_count_based_on_current_queue_length(self, mock_boto3):
         self.input_attrs['queues'] = ['queue1', 'queue2']
 
         sqs_client = mock_boto3.client.return_value
@@ -51,9 +62,92 @@ class TestSqsScaler:
 
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
         sqs_scaler.statsd_client = Mock()
-        assert sqs_scaler.get_desired_instance_count() == 2
+        assert sqs_scaler._get_desired_instance_count_based_on_current_queue_length() == 3
         calls = [
             call("testqueue1.queue-length", 400),
             call("testqueue2.queue-length", 350),
         ]
         sqs_scaler.statsd_client.gauge.assert_has_calls(calls)
+
+    def test_get_desired_instance_count_sums_based_on_queue_length_and_throughput(self, mock_boto3, mocker):
+        self.input_attrs['queues'] = ['queue1', 'queue2']
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        throughput_mock = mocker.patch.object(sqs_scaler, "_get_desired_instance_count_based_on_queue_throughput")
+        queue_length_mock = mocker.patch.object(sqs_scaler, "_get_desired_instance_count_based_on_current_queue_length")
+        throughput_mock.return_value = 2
+        queue_length_mock.return_value = 3
+
+        assert sqs_scaler._get_desired_instance_count() == 5
+
+        throughput_mock.assert_called_once()
+        queue_length_mock.assert_called_once()
+
+    def test_get_desired_instance_count_based_on_queue_throughput(self, mock_boto3, mocker):
+        self.input_attrs['queues'] = ['queue1', 'queue2']
+
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        _get_throughput_mock = mocker.patch.object(sqs_scaler, '_get_throughput', side_effect=[200, 400])
+
+        # threshold is 250
+        assert sqs_scaler._get_desired_instance_count_based_on_queue_throughput() == 3
+
+        assert _get_throughput_mock.call_args_list == [
+            call('queue1'),
+            call('queue2'),
+        ]
+
+    def test_get_throughput_uses_max_value(self, mock_boto3, mocker):
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        _get_sqs_throughput_mock = mocker.patch.object(sqs_scaler, '_get_sqs_throughput', return_value=[100, 200, 50])
+        statsd_mock = mocker.patch.object(sqs_scaler, 'statsd_client')
+
+        assert sqs_scaler._get_throughput('my-queue') == 200
+        # queue prefix "test" pulled from SQS_QUEUE_PREFIX env var
+        statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 200)
+        _get_sqs_throughput_mock.assert_called_once_with('testmy-queue')
+
+    def test_get_throughput_returns_0_if_no_data(self, mock_boto3, mocker):
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        mocker.patch.object(sqs_scaler, '_get_sqs_throughput', return_value=[])
+        statsd_mock = mocker.patch.object(sqs_scaler, 'statsd_client')
+
+        assert sqs_scaler._get_throughput('my-queue') == 0
+        statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 0)
+
+    @freeze_time("2018-03-15 15:10:00")
+    def test_get_sqs_throughput(self, mock_boto3):
+        self.input_attrs['queues'] = ['queue1', 'queue2']
+
+        cloudwatch_client = mock_boto3.client.return_value
+        cloudwatch_client.get_metric_statistics.return_value = {
+            'Datapoints': [
+                {'Sum': 1500, 'Timestamp': 111111110},
+                {'Sum': 1600, 'Timestamp': 111111111},
+                {'Sum': 5500, 'Timestamp': 111111112},
+                {'Sum': 5300, 'Timestamp': 111111113},
+                {'Sum': 2100, 'Timestamp': 111111114},
+            ]}
+
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        assert sqs_scaler._get_sqs_throughput('my-queue') == [1500, 1600, 5500, 5300, 2100]
+
+        cloudwatch_client.get_metric_statistics.assert_called_once_with(
+            Namespace='AWS/SQS',
+            MetricName='NumberOfMessagesReceived',
+            Dimensions=[
+                {
+                    'Name': 'QueueName',
+                    'Value': 'my-queue'
+                },
+            ],
+            StartTime=datetime(2018, 3, 15, 15, 5, 0),
+            EndTime=datetime(2018, 3, 15, 15, 10, 0),
+            Period=60,
+            Statistics=['Sum'],
+            Unit='Count'
+        )


### PR DESCRIPTION
currently we scale based on how many items are in queues waiting to be processed. However, this doesn't distinguish between "lots of items being processed quickly, nothing building up in the queue" (where we shouldn't downscale) and "no items at all coming in to the queue" (where it's okay to downscale).

To solve this, add a check of the NumberOfMessagesReceived metric, which sums up the number of messages entering each queue. In the same way as we scale the web apps based off the ELB, look at the last five minutes and get the max value per minute, then scale based off that.

If there is a large amount of data coming in, AND we have a large amount in the queue already, we want to scale for both of those things, so add together the existing desired instance count and the new one based on messages received.

Also, throughput is much higher than queue length ever gets, and should have its own threshold. In time, we'll probably want to split this up per app (as, for example, create letter tasks have a lower throughput than save notification jobs), but for now, lets hard code it to 1000. This value is based off looking at the save-email-api task