### PR TITLE
Scale to max if surge queue ever has content

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# W503: line break before binary operator
+exclude = venv*,__pycache__,node_modules,cache,migrations,build
+ignore = W503
+max-complexity = 14
+max-line-length = 120
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 config.yml
 data.yml
 venv
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ help:
 dependencies: ## Install build dependencies
 	pip install -r requirements.txt
 
+
+.PHONY: test-dependencies
+test-dependencies: ## Install build test-dependencies
+	pip install -r requirements_for_test.txt
+
+
 generate-config:
 	@$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
 	@echo "COOLDOWN_SECONDS_AFTER_SCALE_UP: 300" >> data.yml
@@ -109,7 +115,7 @@ flake8:
 	flake8 app/ tests/ --max-line-length=120
 
 .PHONY: test
-test: flake8
+test: test-dependencies flake8
 	@$(eval export CONFIG_PATH=$(shell pwd)/config.yml)
 	@$(eval export CF_SPACE=test)
 	@if [ -f data.yml ]; then rm data.yml; fi
@@ -129,6 +135,6 @@ test: flake8
 	@echo "SQS_QUEUE_PREFIX: test" >> data.yml
 	@echo "STATSD_ENABLED: False" >> data.yml
 	@make generate-config
-	STATSD_HOST=testing.local REDIS_URL=redis://redis.local pytest -v --cov=app/ tests/
+	STATSD_HOST=testing.local REDIS_URL=redis://redis.local pytest -v tests/
 	# run specific test with debugger
 	# STATSD_HOST=testing.local REDIS_URL=redis://redis.local pytest -s tests/test_autoscaler.py::TestScale::test_scale_paas_app_handles_deployments

--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -53,10 +53,10 @@ class Autoscaler:
         self.scheduler.enterabs(run_at, 1, self.run_task)
 
     def run(self):
-        print('API endpoint:   {}'.format(self.paas_client.api_url))
-        print('User:           {}'.format(self.paas_client.username))
-        print('Org:            {}'.format(self.paas_client.org))
-        print('Space:          {}'.format(self.paas_client.space))
+        logging.info('API endpoint:   {}'.format(self.paas_client.api_url))
+        logging.info('User:           {}'.format(self.paas_client.username))
+        logging.info('Org:            {}'.format(self.paas_client.org))
+        logging.info('Space:          {}'.format(self.paas_client.space))
 
         self._schedule()
         while True:

--- a/app/cpu_scaler.py
+++ b/app/cpu_scaler.py
@@ -20,4 +20,4 @@ class CpuScaler(PaasBaseScaler):
 
     def _get_cpu_percentages(self):
         paas_app = self.paas_client.get_app_stats(self.app_name)
-        return (instance['stats']['usage']['cpu']*100 for instance in paas_app.values())
+        return (instance['stats']['usage']['cpu'] * 100 for instance in paas_app.values())

--- a/app/elb_scaler.py
+++ b/app/elb_scaler.py
@@ -18,6 +18,15 @@ class ElbScaler(AwsBaseScaler):
             self.cloudwatch_client = super()._get_boto3_client('cloudwatch', region_name=self.aws_region)
 
     def _get_desired_instance_count(self):
+        # we need to get the value even if surge queue has items, so that we update statsd metrics.
+        desired_instance_count = self._get_desired_instance_count_from_request_count()
+
+        if self._surge_queue_has_items():
+            desired_instance_count = self.max_instances
+
+        return desired_instance_count
+
+    def _get_desired_instance_count_from_request_count(self):
         logging.debug('Processing {}'.format(self.app_name))
         request_counts = self._get_request_counts()
         if len(request_counts) == 0:
@@ -29,8 +38,13 @@ class ElbScaler(AwsBaseScaler):
         logging.debug('Highest request count: {}'.format(highest_request_count))
 
         self.gauge("{}.request-count".format(self.app_name), highest_request_count)
-        desired_instance_count = int(math.ceil(highest_request_count / float(self.threshold)))
-        return desired_instance_count
+        return int(math.ceil(highest_request_count / float(self.threshold)))
+
+    def _surge_queue_has_items(self):
+        surge_queue_length = self._get_surge_queue_length()
+        self.gauge("{}.surge-queue".format(self.app_name), surge_queue_length)
+        logging.debug('Surge queue length: {}'.format(surge_queue_length))
+        return surge_queue_length != 0
 
     def _get_request_counts(self):
         self._init_cloudwatch_client()
@@ -54,3 +68,36 @@ class ElbScaler(AwsBaseScaler):
         datapoints = result['Datapoints']
         datapoints = sorted(datapoints, key=lambda x: x['Timestamp'])
         return [row['Sum'] for row in datapoints]
+
+    def _get_surge_queue_length(self):
+        """
+        The Surge Queue is a queue in AWS ELB - if none of our apps accept an incoming connection, it'll queue up to
+        1024 connections that our nginx (really our api) instances aren't able to accept. We shouldn't ever have
+        anything in this queue - so if it's nonzero we should scale up.
+
+        In the short term this metric is stored per second, but we should get the max val from the last 5 minutes anyway
+        to be safe.
+        """
+        self._init_cloudwatch_client()
+        start_time = self._now() - timedelta(**self.request_count_time_range)
+        end_time = self._now()
+
+        results = self.cloudwatch_client.get_metric_statistics(
+            Namespace='AWS/ELB',
+            MetricName='SurgeQueueLength',
+            Dimensions=[
+                {
+                    'Name': 'LoadBalancerName',
+                    'Value': 'notify-paas-proxy'
+                },
+            ],
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=60,
+            Statistics=['Maximum'],
+        )
+        datapoints = results['Datapoints']
+        if datapoints:
+            return max(row['Maximum'] for row in datapoints)
+        else:
+            return 0

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -186,12 +186,12 @@ class TestAutoscalerAlmostEndToEnd:
             'min_instances': 5,
             'max_instances': 10,
             'scalers': [{
-              'type': 'ElbScaler',
-              'elb_name': 'my-elb',
-              'threshold': 300
+                'type': 'ElbScaler',
+                'elb_name': 'my-elb',
+                'threshold': 300
             }, {
-              'type': 'ScheduleScaler',
-              'schedule': '''
+                'type': 'ScheduleScaler',
+                'schedule': '''
 ---
 workdays:
   - 08:00-19:00
@@ -206,6 +206,7 @@ scale_factor: 0.8
         mocker.patch.object(ElbScaler, '_get_boto3_client')
         mocker.patch.object(ElbScaler, 'gauge')
         mocker.patch.object(ElbScaler, '_get_request_counts', return_value=[1300, 1500, 1600, 1700, 1700])
+        mocker.patch.object(ElbScaler, '_get_surge_queue_length', return_value=0)
         mock_paas_client = mocker.patch('app.autoscaler.PaasClient')
         mocker.patch('app.autoscaler.Redis', fakeredis.FakeRedis)
         mock_get_statsd_client = mocker.patch('app.autoscaler.get_statsd_client')

--- a/tests/test_cpu_scaler.py
+++ b/tests/test_cpu_scaler.py
@@ -51,4 +51,4 @@ class TestCpuScaler:
 
 # Create a dictionary that matches the schema of CF `stats` endpoint
 def _get_app_stats(cpus):
-    return {str(idx): {'stats': {'usage': {'cpu': cpu/100}}} for idx, cpu in enumerate(cpus)}
+    return {str(idx): {'stats': {'usage': {'cpu': cpu / 100}}} for idx, cpu in enumerate(cpus)}

--- a/tests/test_elb_scaler.py
+++ b/tests/test_elb_scaler.py
@@ -1,13 +1,14 @@
 from unittest.mock import patch, Mock
-import datetime
+from datetime import datetime
 
+import pytest
 from freezegun import freeze_time
 
 from app.elb_scaler import ElbScaler
 
 app_name = 'test-app'
 min_instances = 1
-max_instances = 2
+max_instances = 5
 
 
 @patch('app.base_scalers.boto3')
@@ -15,7 +16,7 @@ class TestElbScaler:
     input_attrs = {
         'threshold': 1500,
         'elb_name': 'notify-paas-proxy',
-        'request_count_time_range': {'minutes': 10},
+        'request_count_time_range': {'minutes': 5},
     }
 
     def test_init_assigns_relevant_values(self, mock_boto3):
@@ -34,14 +35,14 @@ class TestElbScaler:
         elb_scaler.statsd_client = Mock()
 
         assert elb_scaler.cloudwatch_client is None
-        elb_scaler.get_desired_instance_count()
+
+        elb_scaler._get_desired_instance_count_from_request_count()
+
         assert elb_scaler.cloudwatch_client == mock_client.return_value
         mock_client.assert_called_with('cloudwatch', region_name='eu-west-1')
 
     @freeze_time("2018-03-15 15:10:00")
-    def test_get_desired_instance_count(self, mock_boto3):
-        # set to 5 minutes, to have a smaller mocked response
-        self.input_attrs['request_count_time_range'] = {'minutes': 5}
+    def test_get_desired_instance_count_from_request_count(self, mock_boto3):
         cloudwatch_client = mock_boto3.client.return_value
         cloudwatch_client.get_metric_statistics.return_value = {
             'Datapoints': [
@@ -55,7 +56,7 @@ class TestElbScaler:
         elb_scaler = ElbScaler(app_name, min_instances, max_instances, **self.input_attrs)
         elb_scaler.statsd_client = Mock()
 
-        assert elb_scaler.get_desired_instance_count() == 2
+        assert elb_scaler._get_desired_instance_count_from_request_count() == 4
         cloudwatch_client.get_metric_statistics.assert_called_once_with(
             Namespace='AWS/ELB',
             MetricName='RequestCount',
@@ -65,9 +66,86 @@ class TestElbScaler:
                     'Value': self.input_attrs['elb_name']
                 },
             ],
-            StartTime=elb_scaler._now() - datetime.timedelta(**self.input_attrs['request_count_time_range']),
-            EndTime=elb_scaler._now(),
+            StartTime=datetime(2018, 3, 15, 15, 5, 0),
+            EndTime=datetime(2018, 3, 15, 15, 10, 0),
             Period=60,
             Statistics=['Sum'],
             Unit='Count')
         elb_scaler.statsd_client.gauge.assert_called_once_with("{}.request-count".format(elb_scaler.app_name), 5500)
+
+    @freeze_time("2018-03-15 15:10:00")
+    def test_get_surge_queue_length_returns_highest_value(self, mock_boto3):
+        cloudwatch_client = mock_boto3.client.return_value
+        cloudwatch_client.get_metric_statistics.return_value = {
+            'Datapoints': [
+                {'Maximum': 1, 'Timestamp': 111111110},
+                {'Maximum': 15, 'Timestamp': 111111113},
+                {'Maximum': 3, 'Timestamp': 111111114},
+            ]}
+
+        elb_scaler = ElbScaler(app_name, min_instances, max_instances, **self.input_attrs)
+        elb_scaler.statsd_client = Mock()
+
+        assert elb_scaler._get_surge_queue_length() == 15
+
+        cloudwatch_client.get_metric_statistics.assert_called_once_with(
+            Namespace='AWS/ELB',
+            MetricName='SurgeQueueLength',
+            Dimensions=[
+                {
+                    'Name': 'LoadBalancerName',
+                    'Value': self.input_attrs['elb_name']
+                },
+            ],
+            StartTime=datetime(2018, 3, 15, 15, 5, 0),
+            EndTime=datetime(2018, 3, 15, 15, 10, 0),
+            Period=60,
+            Statistics=['Maximum'],
+        )
+
+    @freeze_time("2018-03-15 15:10:00")
+    def test_get_surge_queue_length_returns_0_when_queue_is_empty(self, mock_boto3):
+        cloudwatch_client = mock_boto3.client.return_value
+        cloudwatch_client.get_metric_statistics.return_value = {'Datapoints': []}
+
+        elb_scaler = ElbScaler(app_name, min_instances, max_instances, **self.input_attrs)
+        elb_scaler.statsd_client = Mock()
+
+        assert elb_scaler._get_surge_queue_length() == 0
+
+    @pytest.mark.parametrize('num_items, expected_return', [(15, True), (0, False)])
+    def test_surge_queue_has_items(self, mock_boto3, mocker, num_items, expected_return):
+        elb_scaler = ElbScaler(app_name, min_instances, max_instances, **self.input_attrs)
+
+        mocker.patch.object(elb_scaler, '_get_surge_queue_length', return_value=num_items)
+        statsd = mocker.patch.object(elb_scaler, 'statsd_client')
+
+        assert elb_scaler._surge_queue_has_items() is expected_return
+
+        statsd.gauge.assert_called_once_with("test-app.surge-queue", num_items)
+
+    @pytest.mark.parametrize('desired_count_from_requests, surge_queue_has_items, expected_count', [
+        (1, True, 5),  # surge queue overrides and sets to max_instances
+        (3, False, 3),  # otherwise we take the desired count from requests
+    ])
+    def test_get_desired_instance_count(
+        self,
+        mock_boto3,
+        mocker,
+        desired_count_from_requests,
+        surge_queue_has_items,
+        expected_count
+    ):
+        elb_scaler = ElbScaler(app_name, min_instances, max_instances, **self.input_attrs)
+        mocker.patch.object(elb_scaler, 'statsd_client')
+        mock_surge_queue = mocker.patch.object(elb_scaler, '_surge_queue_has_items', return_value=surge_queue_has_items)
+        mock_desired_from_requests = mocker.patch.object(
+            ElbScaler,
+            '_get_desired_instance_count_from_request_count',
+            return_value=desired_count_from_requests
+        )
+
+        assert elb_scaler._get_desired_instance_count() == expected_count
+
+        mock_surge_queue.assert_called_once_with()
+        mock_desired_from_requests.assert_called_once_with()


### PR DESCRIPTION
The Surge Queue is a queue in AWS ELB - if none of our apps accept an incoming connection, it'll queue up to 1024 connections that our nginx (really our api) instances aren't able to accept. We shouldn't ever have anything in this queue - so if it's nonzero we should scale up.

In the short term this metric is stored per second, but we should get the max val from the last 5 minutes anyway to be safe.

Scale up to max just to be safe.