### PR TITLE
Allow receipts to scale up to 25 in production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ preview:
 	@echo "CF_SPACE: preview" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
@@ -46,6 +48,8 @@ staging:
 	@echo "CF_SPACE: staging" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -65,6 +69,8 @@ production:
 	@echo "CF_SPACE: production" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 25" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -117,6 +123,8 @@ test: flake8
 	@echo "CF_SPACE: test" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -123,8 +123,8 @@ APPS:
         threshold: 250
 
   - name: notify-delivery-worker-receipts
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    min_instances: {{ MIN_INSTANCE_COUNT_RECEIPTS }}
+    max_instances: {{ MAX_INSTANCE_COUNT_RECEIPTS }}
     scalers:
       - type: SqsScaler
         queues:  [ses-callbacks,sms-callbacks]


### PR DESCRIPTION
We haven't been able to handle the load in the SES queue, it's gone up
to 80000 twice today. The impact of this is that our provider smoke
tests fail and that reply-to emails can't be set for users.

I decided to do this individually for the receipts app, rather than
bumping the `max_instance_count_high` as this would have raised the
number of instances for 6 other apps that don't need it and we shouldn't
add too many apps if we aren't sure we need them to reduce the risk of
running out of DB connections (we are currently running at 3.5k out of
5k).