### PR TITLE
Run save-api-notifications worker at min 18 instances in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
@@ -54,6 +56,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -77,6 +81,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -133,6 +139,8 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -173,8 +173,8 @@ APPS:
         threshold: 500
 
   - name: notify-delivery-worker-save-api-notifications
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    min_instances: {{ MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS }}
+    max_instances: {{ MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS }}
     scalers:
       - type: SqsScaler
         queues:  [save-api-email-tasks]


### PR DESCRIPTION
We did similar for the sender worker in
https://github.com/alphagov/notifications-paas-autoscaler/pull/89

We want to also do this for the save-api-notifications worker because we
are seeing spikes in the queue it pulls from and then it has to scale up
and deal with that. The time to scale means we aren't sending out those
notifications within 10 seconds. This should help us get closer to
meeting that target.

For data see the following and choose to view only the
`livesave-api-email-tasks` queue:
https://grafana-paas.cloudapps.digital/d/9RTLOhyZk/notify-queues?orgId=2&from=1586778806524&to=1586950242673

![image](https://user-images.githubusercontent.com/7228605/79332827-62fcd900-7f15-11ea-81fd-1e9836cd74ce.png)
![image](https://user-images.githubusercontent.com/7228605/79332842-6abc7d80-7f15-11ea-8029-3afa35cf942b.png)

