### PR TITLE
Template preview autoscaling fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# W503: line break before binary operator
+exclude = __pycache__
+ignore = W503
+max-complexity = 14
+max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 config.yml
 data.yml
 venv
+.vscode

--- a/app/cpu_scaler.py
+++ b/app/cpu_scaler.py
@@ -20,4 +20,4 @@ class CpuScaler(PaasBaseScaler):
 
     def _get_cpu_percentages(self):
         paas_app = self.paas_client.get_app_stats(self.app_name)
-        return (instance['stats']['usage']['cpu']*100 for instance in paas_app.values())
+        return (instance['stats']['usage']['cpu'] * 100 for instance in paas_app.values())

--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -13,8 +13,8 @@ THROUGHPUT_OF_TASKS_PER_WORKER_PER_MINUTE = 1000
 class SqsScaler(AwsBaseScaler):
     def __init__(self, app_name, min_instances, max_instances, **kwargs):
         super().__init__(app_name, min_instances, max_instances, kwargs.get('aws_region'))
-        self.queue_length_threshold = kwargs['threshold']
-        self.throughput_threshold = THROUGHPUT_OF_TASKS_PER_WORKER_PER_MINUTE
+        self.queue_length_threshold = kwargs.get('threshold') or kwargs['allowed_queue_backlog_per_worker']
+        self.throughput_threshold = kwargs.get('tasks_per_worker_per_minute', THROUGHPUT_OF_TASKS_PER_WORKER_PER_MINUTE)
         self.queues = kwargs['queues'] if isinstance(kwargs['queues'], list) else [kwargs['queues']]
         self.sqs_queue_prefix = config['SCALERS']['SQS_QUEUE_PREFIX']
         self.request_count_time_range = kwargs.get('request_count_time_range', {'minutes': 5})

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -159,7 +159,7 @@ APPS:
     max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
     scalers:
       - type: SqsScaler
-        queues:  [antivirus-tasks, letter-tasks, sanitise-letter-tasks]
+        queues:  [sanitise-letter-tasks]
         tasks_per_worker_per_minute: 25
         allowed_queue_backlog_per_worker: 25
 

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -144,8 +144,10 @@ APPS:
       - type: ScheduledJobsScaler
         threshold: 8
       - type: SqsScaler
-        queues:  [create-letters-pdf-tasks, letter-tasks, retry-tasks]
-        threshold: 8
+        queues:  [create-letters-pdf-tasks]
+        # 5 gunicorn workers per * 60 seconds * pessimistic 1 second per request avg = 300 requests per minute
+        tasks_per_worker_per_minute: 300
+        allowed_queue_backlog_per_worker: 100
       - type: ScheduleScaler
         schedule:
           scale_factor: 0.4

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -160,7 +160,8 @@ APPS:
     scalers:
       - type: SqsScaler
         queues:  [antivirus-tasks, letter-tasks, sanitise-letter-tasks]
-        threshold: 100
+        tasks_per_worker_per_minute: 25
+        allowed_queue_backlog_per_worker: 25
 
   - name: notify-delivery-worker-service-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -186,12 +186,12 @@ class TestAutoscalerAlmostEndToEnd:
             'min_instances': 5,
             'max_instances': 10,
             'scalers': [{
-              'type': 'ElbScaler',
-              'elb_name': 'my-elb',
-              'threshold': 300
+                'type': 'ElbScaler',
+                'elb_name': 'my-elb',
+                'threshold': 300
             }, {
-              'type': 'ScheduleScaler',
-              'schedule': '''
+                'type': 'ScheduleScaler',
+                'schedule': '''
 ---
 workdays:
   - 08:00-19:00

--- a/tests/test_cpu_scaler.py
+++ b/tests/test_cpu_scaler.py
@@ -51,4 +51,4 @@ class TestCpuScaler:
 
 # Create a dictionary that matches the schema of CF `stats` endpoint
 def _get_app_stats(cpus):
-    return {str(idx): {'stats': {'usage': {'cpu': cpu/100}}} for idx, cpu in enumerate(cpus)}
+    return {str(idx): {'stats': {'usage': {'cpu': cpu / 100}}} for idx, cpu in enumerate(cpus)}

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -34,6 +34,23 @@ class TestSqsScaler:
 
         assert sqs_scaler.queues == ['queue1']
 
+    def test_init_sets_throughput_threshold_from_tasks_per_worker_per_minute_if_provided(self, mock_boto3):
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **{
+            'threshold': 100,
+            'tasks_per_worker_per_minute': 5,
+            'queues': []
+        })
+        assert sqs_scaler.queue_length_threshold == 100
+        assert sqs_scaler.throughput_threshold == 5
+
+    def test_init_sets_queue_threshold_from_allowed_queue_backlog_per_worker_if_threshold_not_set(self, mock_boto3):
+        sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **{
+            'allowed_queue_backlog_per_worker': 5,
+            'queues': []
+        })
+        assert sqs_scaler.queue_length_threshold == 5
+        assert sqs_scaler.throughput_threshold == 1000
+
     def test_client_initialization(self, mock_boto3):
         self.input_attrs['queues'] = ['queue1', 'queue2']
         mock_client = mock_boto3.client


### PR DESCRIPTION
Please review commit by commit. Note: I am not wedded to all these ideas and the numbers are mostly just best guesses or stabs in the dark. I've tried to explain myself in commits and comments but I am very open to different views on what numbers we should scale at/to.

The numbers changes:

### update thresholds for template-preview-celery

set tasks_per_worker_per_minute to 25 (as seen when under load), rather than the default of 1000.

rename threshold to allowed_queue_backlog_per_worker so it makes more sense in context in the config file, and also set it to 25 so that we add a worker per minutes worth of work on the backlog.

### don't scale template preview celery based on antivirus or letter queues 

this was set up to try and predict load. However, since we've improved scaling we're much better at reacting quickly to bursts of load. There are lots of other tasks processed by letter-tasks, so I think scaling based on those tasks is less neccessary now.

### reduce notify-template-preview scaling 

set tasks per worker per minute to 300. This is based on 5 gunicorn worker threads processing 1 task per second each over 60 seconds. Over the last week, we've had 62% of requests to /print.pdf (the only endpoint hit from the create-letters-pdf-tasks worker) under 1 second, 31% between 1 and 2 seconds, and 8% over 2 seconds.

Note: this doesn't take into account the baseline of admin traffic, which is approximately 36% of the traffic, and has a similar response time spread. But we shouldn't scale the app for admin traffic based on the queue workers. In an ideal world we would scale based on traffic to template preview itself as well as the SQS queues.

set allowed queue backlog per worker to 100. If the queue has grown to 100 items, create another instance to help deal with the backlog