### PR TITLE
Revert "Match staging settings to prod for load testing"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,25 +52,25 @@ staging:
 	@if [ -f data.yml ]; then rm data.yml; fi
 	@echo "---" >> data.yml
 	@echo "CF_SPACE: staging" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 25" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_SENDER: 30" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SENDER: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_CALLBACK: 15" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
-	@echo "SCHEDULE_SCALER_ENABLED: True" >> data.yml
+	@echo "SCHEDULE_SCALER_ENABLED: False" >> data.yml
 	@echo "SQS_QUEUE_PREFIX: staging" >> data.yml
 	@echo "STATSD_ENABLED: True" >> data.yml
 	@$(eval export CF_SPACE=staging)


### PR DESCRIPTION
Reverts alphagov/notifications-paas-autoscaler#97

We no longer need staging to match prod as we aren't due to test for at least a few days and so this will save us some money