### PR TITLE
Allow template preview celery to scale up to 35 instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ preview:
 	@echo "CF_SPACE: preview" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 1" >> data.yml
@@ -54,6 +56,8 @@ staging:
 	@echo "CF_SPACE: staging" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml
@@ -81,6 +85,8 @@ production:
 	@echo "CF_SPACE: production" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 8" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 40" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
@@ -141,6 +147,8 @@ test: flake8
 	@echo "CF_SPACE: test" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -161,8 +161,8 @@ APPS:
             - 08:00-19:00
 
   - name: notify-template-preview-celery
-    min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    min_instances: {{ MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY }}
+    max_instances: {{ MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY }}
     scalers:
       - type: SqsScaler
         queues:  [sanitise-letter-tasks]


### PR DESCRIPTION
Last week had the smoke tests fail because a letter took more than
a minute to make it through template preview. This was caused by
template preview celery being underscaled. This was concluded by looking
at the number of items being put on the queue vs the number of items
being pulled off it. The number of items being put on was higher than
the ability to process them all for about 10 minutes, causing a delay
and the smoke tests to fail.

It is debatable whether we should keep scaling this app horizontally
(more instances) as this costs money. At some point we should work out
what our time threshold is for a letter to work it's through antivirus
and template preview and scale to keep letter processing under that
threshold. At the moment it's implied to be a minute based on smoke
tests but I don't know if that is a correct assumption or just happens
to be that way.

![image](https://user-images.githubusercontent.com/7228605/87292977-8970e700-c4f9-11ea-886f-924ecf84543d.png)
