### PR TITLE
Rename variables for clarity

### DIFF
--- a/app/sqs_scaler.py
+++ b/app/sqs_scaler.py
@@ -31,12 +31,12 @@ class SqsScaler(AwsBaseScaler):
 
     def _get_desired_instance_count(self):
         logging.debug('Processing {}'.format(self.app_name))
-        desired_instance_count_throughput = self._get_desired_instance_count_based_on_queue_throughput()
-        desired_instance_count_queue_length = self._get_desired_instance_count_based_on_current_queue_length()
+        instance_count_throughput = self._get_desired_instance_count_based_on_throughput_of_tasks_pulled_from_queues()
+        instance_count_queue_length = self._get_desired_instance_count_based_on_current_queue_length()
         # How many instances we run should be enough to handle the current level of throughput, however
         # if the throughput remains the same and we already have items building up in our queue, then we
         # wish to scale even higher to bring the queue down
-        return desired_instance_count_throughput + desired_instance_count_queue_length
+        return instance_count_throughput + instance_count_queue_length
 
     def _get_desired_instance_count_based_on_current_queue_length(self):
         total_message_count = self._get_total_message_count(self.queues)
@@ -44,8 +44,8 @@ class SqsScaler(AwsBaseScaler):
         desired_instance_count = int(math.ceil(total_message_count / float(self.queue_length_threshold)))
         return desired_instance_count
 
-    def _get_desired_instance_count_based_on_queue_throughput(self):
-        total_throughput = self._get_total_throughput(self.queues)
+    def _get_desired_instance_count_based_on_throughput_of_tasks_pulled_from_queues(self):
+        total_throughput = self._get_total_throughput_of_tasks_pulled_from_queues(self.queues)
         logging.debug('Total throughput: {}'.format(total_throughput))
         desired_instance_count = int(math.ceil(total_throughput / float(self.throughput_threshold)))
         return desired_instance_count
@@ -76,7 +76,7 @@ class SqsScaler(AwsBaseScaler):
     def _get_total_message_count(self, queues):
         return sum(self._get_message_count(queue) for queue in queues)
 
-    def _get_sqs_throughput(self, name):
+    def _get_sqs_throughput_of_tasks_pulled_from_queue(self, name):
         self._init_cloudwatch_client()
         start_time = self._now() - timedelta(**self.request_count_time_range)
         end_time = self._now()
@@ -99,20 +99,20 @@ class SqsScaler(AwsBaseScaler):
         datapoints = sorted(datapoints, key=lambda x: x['Timestamp'])
         return [row['Sum'] for row in datapoints]
 
-    def _get_throughput(self, queue):
+    def _get_throughput_of_tasks_pulled_from_queue(self, queue):
         queue_name = self._get_sqs_queue_name(queue)
-        past_5_mins_of_throughput = self._get_sqs_throughput(queue_name)
+        past_5_mins_of_throughput = self._get_sqs_throughput_of_tasks_pulled_from_queue(queue_name)
 
         if len(past_5_mins_of_throughput) == 0:
             past_5_mins_of_throughput = [0]
-        logging.debug('Queue throughput: {}'.format(past_5_mins_of_throughput))
+        logging.debug('Throughput of tasks pulled from queue: {}'.format(past_5_mins_of_throughput))
 
         # Keep the highest throughput over the specified time range
         highest_throughput = max(past_5_mins_of_throughput)
-        logging.debug('Highest queue throughput: {}'.format(highest_throughput))
+        logging.debug('Highest throughput of tasks pulled from queue: {}'.format(highest_throughput))
 
         self.gauge("{}.queue-throughput".format(queue_name), past_5_mins_of_throughput[-1])
         return highest_throughput
 
-    def _get_total_throughput(self, queues):
-        return sum(self._get_throughput(queue) for queue in queues)
+    def _get_total_throughput_of_tasks_pulled_from_queues(self, queues):
+        return sum(self._get_throughput_of_tasks_pulled_from_queue(queue) for queue in queues)

--- a/tests/test_sqs_scaler.py
+++ b/tests/test_sqs_scaler.py
@@ -91,7 +91,9 @@ class TestSqsScaler:
         self.input_attrs['queues'] = ['queue1', 'queue2']
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        throughput_mock = mocker.patch.object(sqs_scaler, "_get_desired_instance_count_based_on_queue_throughput")
+        throughput_mock = mocker.patch.object(
+            sqs_scaler, "_get_desired_instance_count_based_on_throughput_of_tasks_pulled_from_queues"
+        )
         queue_length_mock = mocker.patch.object(sqs_scaler, "_get_desired_instance_count_based_on_current_queue_length")
         throughput_mock.return_value = 2
         queue_length_mock.return_value = 3
@@ -106,10 +108,12 @@ class TestSqsScaler:
 
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        _get_throughput_mock = mocker.patch.object(sqs_scaler, '_get_throughput', side_effect=[2000, 800])
+        _get_throughput_mock = mocker.patch.object(
+            sqs_scaler, '_get_throughput_of_tasks_pulled_from_queue', side_effect=[2000, 800]
+        )
 
         # threshold is 1000
-        assert sqs_scaler._get_desired_instance_count_based_on_queue_throughput() == 3
+        assert sqs_scaler._get_desired_instance_count_based_on_throughput_of_tasks_pulled_from_queues() == 3
 
         assert _get_throughput_mock.call_args_list == [
             call('queue1'),
@@ -119,10 +123,12 @@ class TestSqsScaler:
     def test_get_throughput_uses_max_value(self, mock_boto3, mocker):
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        _get_sqs_throughput_mock = mocker.patch.object(sqs_scaler, '_get_sqs_throughput', return_value=[100, 200, 50])
+        _get_sqs_throughput_mock = mocker.patch.object(
+            sqs_scaler, '_get_sqs_throughput_of_tasks_pulled_from_queue', return_value=[100, 200, 50]
+        )
         statsd_mock = mocker.patch.object(sqs_scaler, 'statsd_client')
 
-        assert sqs_scaler._get_throughput('my-queue') == 200
+        assert sqs_scaler._get_throughput_of_tasks_pulled_from_queue('my-queue') == 200
         # queue prefix "test" pulled from SQS_QUEUE_PREFIX env var
         statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 50)
         _get_sqs_throughput_mock.assert_called_once_with('testmy-queue')
@@ -130,10 +136,12 @@ class TestSqsScaler:
     def test_get_throughput_returns_0_if_no_data(self, mock_boto3, mocker):
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        mocker.patch.object(sqs_scaler, '_get_sqs_throughput', return_value=[])
+        mocker.patch.object(
+            sqs_scaler, '_get_sqs_throughput_of_tasks_pulled_from_queue', return_value=[]
+        )
         statsd_mock = mocker.patch.object(sqs_scaler, 'statsd_client')
 
-        assert sqs_scaler._get_throughput('my-queue') == 0
+        assert sqs_scaler._get_throughput_of_tasks_pulled_from_queue('my-queue') == 0
         statsd_mock.gauge.assert_called_once_with('testmy-queue.queue-throughput', 0)
 
     @freeze_time("2018-03-15 15:10:00")
@@ -152,7 +160,7 @@ class TestSqsScaler:
 
         sqs_scaler = SqsScaler(app_name, min_instances, max_instances, **self.input_attrs)
 
-        assert sqs_scaler._get_sqs_throughput('my-queue') == [1500, 1600, 5500, 5300, 2100]
+        assert sqs_scaler._get_sqs_throughput_of_tasks_pulled_from_queue('my-queue') == [1500, 1600, 5500, 5300, 2100]
 
         cloudwatch_client.get_metric_statistics.assert_called_once_with(
             Namespace='AWS/SQS',


### PR DESCRIPTION
We previously misunderstood the `NumberOfMessagesReceived` metric. We
thought it was measuring the number of messages received on to the
queues. But in fact it is the number of messages received by our apps
from the queues. The metric from number of messages received on to the
queues is 'NumberOfMessagesSent'.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html