### PR TITLE
Set delivery-jobs-worker to 25 instances min and max

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
@@ -66,6 +68,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -95,6 +99,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_JOBS: 25" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
@@ -157,6 +163,8 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -59,8 +59,8 @@ APPS:
             - 08:00-23:00
 
   - name: notify-delivery-worker-jobs
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_HIGH }}
+    min_instances: {{ MIN_INSTANCE_COUNT_JOBS }}
+    max_instances: {{ MAX_INSTANCE_COUNT_JOBS }}
     scalers:
       - type: SqsScaler
         queues:  [database-tasks, job-tasks]


### PR DESCRIPTION
We want to stop it scaling down for the moment because we have lots of
big CSVs to process and want it to be ready for them when they come.

We also raise it from 20 to 25 max as it's not keeping up with the
numbers of CSVs that are being uploaded.

There could be knock on effects further down the change so we aren't
bumping up the max number of instances too high in one go and will need
to monitor.