### PR TITLE
Allow receipts worker to scale to 30 instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ production:
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 25" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 30" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 30" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml


### PR DESCRIPTION
At high loads, we are seeing the queue building up and smoke tests fail
because we aren't able to process tasks of this queue quick enough. We
allow it to scale to 30 instead of 35 max. This should help but not be
too big a jump that we risk a big increase in DB connections.