### PR TITLE
Change minimum number of job workers back to 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_JOBS: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml


### PR DESCRIPTION
it was previously changed to run at minimum of 25 (same as the max) so
that we weren't scaling and we were ready for large amounts of load
during a busy weekend.

This now sets it back to what the original minimum was pre weekend of 2
instances (the same value as `MIN_INSTANCE_COUNT_LOW`).