### PR TITLE
Add scaling for api sms callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config.yml
 data.yml
 venv
 .vscode
+.idea/

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -41,6 +41,14 @@ APPS:
           weekends:
             - 08:00-23:00
 
+  - name: notify-api-sms-callbacks
+    min_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    max_instances: {{ MAX_INSTANCE_COUNT_API }}
+    scalers:
+      - type: SqsScaler
+        queues:  [send-sms-tasks]
+        threshold: 250
+
   - name: notify-delivery-worker-sender
     min_instances: {{ MIN_INSTANCE_COUNT_SENDER }}
     max_instances: {{ MAX_INSTANCE_COUNT_SENDER }}

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -30,9 +30,6 @@ APPS:
     min_instances: {{ MIN_INSTANCE_COUNT_API }}
     max_instances: {{ MAX_INSTANCE_COUNT_API }}
     scalers:
-      - type: ElbScaler
-        elb_name: 'notify-paas-proxy'
-        threshold: 600
       - type: ScheduleScaler
         schedule:
           scale_factor: 0.6


### PR DESCRIPTION
Review this PR commit by commit.
First commit:
Add autoscaling for the notify-api-sms-callback app based on the size of the send-sms-task. 

Second commit:
This commit is only to raise a conversation about the notify-api scaling section. 
Remove elb scaling for the notify-api because we have the min and max instance count set to the same number. This is because the scaling for the the notify-api didn't react in time to large spikes. Removing this is not necessary, but thought I'd bring up the point that actually we are not autoscaling the notify-api app at all. Should we just remove it all together?