### PR TITLE
Temporary bump to min instance count for notify-delivery-worker-reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_SENDER: 30" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_REPORTING: 1" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml


### PR DESCRIPTION
Bump up the min instance count for the production notify-delivery-worker-reporting.

We need to rerun some reporting tasks for all of October, with only 1 instance running I'll be here until Christmas.