### PR TITLE
Allow worker apps to scale higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ production:
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 30" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 50" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SENDER: 30" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 25" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 50" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 2" >> data.yml


### PR DESCRIPTION
This is the equivalent of
https://github.com/alphagov/notifications-paas-autoscaler/pull/111 but
for production. These changes have been load tested on staging and give
us good results, allowing us to handle 800 notifications per second
without delays.