### PR TITLE
Add scaling for the notify-api-sms-callback app.

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -30,9 +30,18 @@ APPS:
     min_instances: {{ MIN_INSTANCE_COUNT_API }}
     max_instances: {{ MAX_INSTANCE_COUNT_API }}
     scalers:
-      - type: ElbScaler
-        elb_name: 'notify-paas-proxy'
-        threshold: 600
+      - type: ScheduleScaler
+        schedule:
+          scale_factor: 0.6
+          workdays:
+            - 08:00-23:00
+          weekends:
+            - 08:00-23:00
+
+  - name: notify-api-sms-callbacks
+    min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
+    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    scalers:
       - type: ScheduleScaler
         schedule:
           scale_factor: 0.6

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -44,7 +44,7 @@ APPS:
     scalers:
       - type: ScheduleScaler
         schedule:
-          scale_factor: 0.6
+          scale_factor: 1.0
           workdays:
             - 08:00-23:00
           weekends:


### PR DESCRIPTION
From the hours of 08:00 to 23:00 scale the app to 10 instances, during off hours scale to 4 instances on production.

Remove the ElbScaler on notify-api since it is not doing anything because the min and max instance numbers are the same (always 35). Which leads to the question, should we just remove notify-api from this script altogether.