### PR TITLE
Scale research worker to max 30 instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RESEARCH: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 1" >> data.yml
@@ -73,6 +75,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
@@ -104,6 +108,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 30" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 15" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
@@ -172,6 +178,8 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 30" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -98,10 +98,9 @@ APPS:
       - type: SqsScaler
         queues:  [create-letters-pdf-tasks, letter-tasks]
         threshold: 250
-
   - name: notify-delivery-worker-research
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    min_instances: {{ MIN_INSTANCE_COUNT_RESEARCH }}
+    max_instances: {{ MAX_INSTANCE_COUNT_RESEARCH }}
     scalers:
       - type: SqsScaler
         queues:  [research-mode-tasks]


### PR DESCRIPTION
It currently is allowed to scale up to 10 instances

When a team load tested using test API keys at 200/s we saw that 10
instances couldn't handle that and that a large queue built up.

We know have a request to load test at 650/s. Therefore if we triple the
number of instances our performance should get no worse.

There is an argument that we should let this scale above 30 workers but
I don't want to give too many instances to start with because they use
DB connections and whilst it's likely to be OK, I would rather still see
some delays for test notification processing then risk changing our
system too much.