### PR TITLE
Scale research worker higher to support 600rps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_RESEARCH: 30" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 50" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 15" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml


### PR DESCRIPTION
We've had a short load test at 600rps using test keys. This led to
delays and we build up a queue.

They are now going to test for more like an hour at this rate and the
queue will continue to grow. If that is not acceptable then we should
scale this worker up.

Based on a graph of how many tasks we were taking from the queue when
running 10 instances, it was about 10K per minute. At a rate of 600rps
we put about 50K tasks on a queue per minute. Therefore, 50 instances
should roughly handle 600rps.

Graph of picking up tasks per minute when running 10 instances a couple of weeks ago. Note, the title says 'how many tasks are put onto the queue' but this title is actually incorrect and it is how many tasks are pulled OFF the queue by our apps.

![image](https://user-images.githubusercontent.com/7228605/103901387-feac2600-50f0-11eb-847d-5df508d0f9af.png)

Graph of tasks being put onto the queue per minute from the short load test today
![image](https://user-images.githubusercontent.com/7228605/103901518-29967a00-50f1-11eb-8cd1-454c7a29e0f9.png)

