### PR TITLE
Set instance count for broadcasts worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 1" >> data.yml
@@ -73,6 +75,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
@@ -106,6 +110,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
@@ -176,6 +182,8 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -203,3 +203,11 @@ APPS:
       - type: SqsScaler
         queues:  [antivirus-tasks]
         threshold: 50
+
+  - name: notify-delivery-worker-broadcasts
+    min_instances: {{ MIN_INSTANCE_COUNT_BROADCASTS }}
+    max_instances: {{ MAX_INSTANCE_COUNT_BROADCASTS }}
+    scalers:
+      - type: SqsScaler
+        queues:  [broadcast-tasks]
+        threshold: 50


### PR DESCRIPTION
Note, it is always set as 2 in production because it's highly unlikely
we will get many tasks put on the queue at a time (potentially 4 or 5 at
a time).

We could have done this by just setting the number of instances in the
API manifest to keep it at 2 instances always, but we added it here as
it gives us metrics for queue length/tasks picked up etc in grafana
automatically. Therefore, the threshold choice of 50 is fairly abitrary
as I don't expect it to ever scale based on this (if it could as it's
already at it's max).



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
