### PR TITLE
Pin broadcast worker to 2 instances on preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml


### PR DESCRIPTION
We're seeing a lot of instances of the broadcast worker stopping and starting on preview. We reckon this might be due to how the SqsScaler works when there are very low volumes on the queue. The broadcast worker scaling is configured with a threshold of 50, and only ever a handful of items on the queue at any time.

Both `_get_desired_instance_count_based_on_throughput_of_tasks_put_onto_queues` and `_get_desired_instance_count_based_on_current_queue_length` will return 1 if there is any data, or 0 if there is no data, and then we add the two values together to get the overall desired_instance_count. The min and max of the broadcast worker on preview is min 1 and max 2.

The queue length metric gets the current available items, which is almost always 0 for this worker.

The throughput metric gets the max 1 min value of tasks put on to the queue in the last 5 mins. Given the worker is mostly just doing 4 link tests every 15 mins, we expect this value to be 4 for a five minute period, then down to 0 for the next 10 minutes, cycling like that forever.

When either value is 0, autoscaler tries to scale down to 1 instance. When both values are non-zero, autoscaler will scale up to 2 instances. This autoscaling is happening quite a lot (eg we scaled up and down 15 times overnight when there's no other activity on the queues).

We have a theory that these downscales might be messing with retry logic.

Pin to two instances so that we don't see this scaling and can test our theory.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
