### PR TITLE
Increase the MAX_INSTANCE_COUNT_CALLBACK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ production:
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RESEARCH: 50" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_CALLBACK: 15" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml


### PR DESCRIPTION
Increase the MAX_INSTANCE_COUNT_CALLBACK for the notify-delivery-worker-service-callbacks app.

I've checked with a high volume service and they are ok with scaling the app up.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
