### PR TITLE
Use cpu scaler on notify-api-sms-callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_CALLBACKS: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: False" >> data.yml
@@ -85,6 +86,7 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_CALLBACKS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: False" >> data.yml
@@ -120,6 +122,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_CALLBACKS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: True" >> data.yml
@@ -192,6 +195,7 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_CALLBACKS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: True" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -40,7 +40,7 @@ APPS:
 
   - name: notify-api-sms-callbacks
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
-    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    max_instances: {{ MAX_INSTANCE_COUNT_API_SMS_CALLBACKS }}
     scalers:
       - type: CpuScaler
         threshold: {{ DEFAULT_CPU_PERCENTAGE_THRESHOLD }}

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -42,6 +42,8 @@ APPS:
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
     scalers:
+      - type: CpuScaler
+        threshold: {{ DEFAULT_CPU_PERCENTAGE_THRESHOLD }}
       - type: ScheduleScaler
         schedule:
           scale_factor: 1.0


### PR DESCRIPTION
I don't think we've tried this scaler before, so we should probably keep an eye on it. 

As far as I can tell the worst case scenario is that it's not going to make a difference.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
