### PR TITLE
Rename notify-api-sms-callbacks to notify-api-sms-receipts

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -38,7 +38,7 @@ APPS:
           weekends:
             - 08:00-23:00
 
-  - name: notify-api-sms-callbacks
+  - name: notify-api-sms-receipts
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
     max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
     scalers:


### PR DESCRIPTION
The app has been renamed so we need to change the autoscaler config too



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
