### PR TITLE
Bump max api-sms-receipts instances to 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_RECEIPTS: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 1" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: False" >> data.yml
@@ -85,6 +86,7 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_RECEIPTS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: False" >> data.yml
@@ -120,6 +122,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_RECEIPTS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: True" >> data.yml
@@ -192,6 +195,7 @@ test: flake8
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 7" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_API_SMS_RECEIPTS: 15" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_HIGH: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_LOW: 2" >> data.yml
 	@echo "SCHEDULE_SCALER_ENABLED: True" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -40,7 +40,7 @@ APPS:
 
   - name: notify-api-sms-receipts
     min_instances: {{ MIN_INSTANCE_COUNT_HIGH }}
-    max_instances: {{ MAX_INSTANCE_COUNT_MEDIUM }}
+    max_instances: {{ MAX_INSTANCE_COUNT_API_SMS_RECEIPTS }}
     scalers:
       - type: ScheduleScaler
         schedule:


### PR DESCRIPTION
After the incident on Friday 26/3 we feel that 10 might be too few
instances. Given that this app does not talk to the database (thus not
risking an increase in db connections) we can safely increase its
instance count.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
