### PR TITLE
Update runtime to Python 3.9

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.x
+python-3.9.x


### PR DESCRIPTION
I’ve tested locally that the tests pass in a clean Python 3.9 environment.

This app doesn’t seem to have a `freeze-requirements` step like others do.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
