### PR TITLE
Bump max research workers from 50 to 60

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ production:
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_RESEARCH: 50" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_RESEARCH: 60" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_CALLBACK: 30" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml


### PR DESCRIPTION
We are currently seeing the research worker developing queues that
they are not keeping up with.

We are currently running on 50 research workers and they appear to
be handling just under 50K tasks per minute. We are putting just
over 50K tasks on the queue per minute so hopefully this 20% increase
in workers will hit the sweet spot to catch up and bring down the queue.

Note, the research worker does touch the DB. Currently the DB health
is looking good, in particular DB connections, such that I don't think
this is a particularly risky change.

![image](https://user-images.githubusercontent.com/7228605/133623213-a474c961-ece4-48a5-b58e-19458442def8.png)



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
