### PR TITLE
Fix not being able to deploy locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SHELL := /bin/bash
 CF_APP = notify-paas-autoscaler
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
+NOTIFY_CREDENTIALS ?= ~/.notify-credentials
+
 .PHONY: help
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This is the same as our other repos [1].

[1]: https://github.com/alphagov/notifications-api/blob/32873ef70f817f81699e1759caf6704773e6d836/Makefile#L19




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)