### PR TITLE
Decrease log level to INFO

### DIFF
--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -82,7 +82,7 @@ class Autoscaler:
         except InvalidStatusCode as e:
             if e.body.get('error_code') == 'CF-ScaleDisabledDuringDeployment':
                 msg = 'Cannot scale during deployment {}'.format(app.name)
-                logging.info(msg)
+                logging.debug(msg)
             else:
                 msg = 'Failed to scale {}: {}'.format(app.name, str(e))
                 logging.error(msg)
@@ -94,11 +94,11 @@ class Autoscaler:
         if desired < current:
 
             if self._recent_scale(app_name, 'last_scale_up', self.cooldown_seconds_after_scale_up):
-                logging.info("Skipping scale down due to recent scale up event")
+                logging.debug("Skipping scale down due to recent scale up event")
                 return current
 
             if self._recent_scale(app_name, 'last_scale_down', self.cooldown_seconds_after_scale_down):
-                logging.info("Skipping scale down due to a recent scale down event")
+                logging.debug("Skipping scale down due to a recent scale down event")
                 return current
 
             self._set_last_scale('last_scale_down', app_name, self._now())

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 from app.autoscaler import Autoscaler
 
 logging.basicConfig(
-    level=logging.WARNING,
+    level=logging.INFO,
     handlers=[
         logging.FileHandler('/home/vcap/logs/app.log'),
         logging.StreamHandler(sys.stdout),

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -132,7 +132,7 @@ class TestScale:
         mock_paas_client.return_value.assert_not_called()
 
     def test_scale_paas_app_handles_deployments(self, mock_get_statsd_client, mock_paas_client, _, caplog):
-        caplog.set_level(logging.INFO)
+        caplog.set_level(logging.DEBUG)
         app_name = 'app-name-1'
         app_guid = '11111-11111-11111111-1111'
         cf_info = {'name': app_name, 'instances': 4, 'guid': app_guid}
@@ -153,7 +153,7 @@ class TestScale:
         mock_paas_client.return_value.update.assert_called_once_with(app_guid, 6)
         assert caplog.record_tuples == [
             ('root', logging.INFO, 'Scaling app-name-1 from 4 to 6'),
-            ('root', logging.INFO, 'Cannot scale during deployment app-name-1')
+            ('root', logging.DEBUG, 'Cannot scale during deployment app-name-1')
         ]
 
     def test_scale_paas_app_handles_unexpected_errors(self, mock_get_statsd_client, mock_paas_client, _, caplog):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180017131

This is consistent with our other repos [1] and the previous high
level doesn't seem to be necessary [2].

Having more logs from this app would make it easier to 
analyse how often it's scaling instances.

[1]: https://github.com/alphagov/notifications-utils/blob/master/notifications_utils/logging.py#L20
[2]: https://github.com/alphagov/notifications-paas-autoscaler/commit/ddeafbb5950f4a9d7db2ae21f3ba28dc28805be5




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)