### PR TITLE
Increase instances for worker-sender for staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ staging:
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 50" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_SENDER: 30" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_SENDER: 45" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 18" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_SAVE_API_NOTIFICATIONS: 50" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_REPORTING: 3" >> data.yml


### PR DESCRIPTION
We are doing this to see if staging can take a bigger load if we scale this app that was struggling at 1000 requests per second.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
