### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-boto3==1.17.38
-cloudfoundry-client==1.16.1
-psycopg2-binary==2.8.6
-pyyaml==5.4.1
-redis==3.5.3
-pytz==2021.1
+boto3==1.21.35
+cloudfoundry-client==1.30.0
+psycopg2-binary==2.9.3
+pyyaml==6.0
+redis==4.1.4
+pytz==2022.1
 
-git+https://github.com/alphagov/notifications-utils.git@44.0.2#egg=notifications-utils==44.0.2
+git+https://github.com/alphagov/notifications-utils.git@55.1.2#egg=notifications-utils==55.1.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,11 +1,11 @@
-fakeredis==1.5.0
-flake8==3.7.9
-freezegun==0.3.15
-isort==5.8.0
-jinja2-cli[yaml]==0.7.0
-pytest-cov==2.8.1
-pytest-mock==2.0.0
-pytest-randomly==3.6.0
-pytest==5.3.5
+fakeredis==1.7.1
+flake8==4.0.1
+freezegun==1.2.1
+isort==5.10.1
+jinja2-cli[yaml]==0.8.2
+pytest-cov==3.0.0
+pytest-mock==3.7.0
+pytest-randomly==3.11.0
+pytest==7.1.1
 
 -r requirements.txt

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -174,7 +174,7 @@ class TestScale:
         mock_paas_client.return_value.update.assert_called_once_with(app_guid, 6)
         assert caplog.record_tuples == [
             ('root', logging.INFO, 'Scaling app-name-1 from 4 to 6'),
-            ('root', logging.ERROR, 'Failed to scale app-name-1: BAD_REQUEST : {"description": "something bad"}')
+            ('root', logging.ERROR, 'Failed to scale app-name-1: BAD_REQUEST = {"description": "something bad"}')
         ]
 
 


### PR DESCRIPTION
**Bump all test requirements**

**Bump production dependencies**
This bumps all production dependencies in the same commit, since there were dependency conflicts when trying to do them one by one. Everything is bumped to the latest version apart from Redis - we're using version `4.1.4` instead of the latest of `4.2.2` in order to avoid conflicts with fakeredis.

There's a minor change to a log line, but nothing else in the new versions which looked like it would affect our code.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
