### PR TITLE
switch from redislabs to paas redis

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -21,3 +21,4 @@ applications:
     services:
       - notify-db
       - logit-ssl-syslog-drain
+      - notify-redis


### PR DESCRIPTION
following admin/api. Note that since there's only ever one instance of the paas autoscaler, we don't need to worry about making this a zero-downtimey two phase deploy. rather, we can just make sure redis exists in each environment then can just push this out before we delete the databases across our environments

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
