### PR TITLE
Remove REDIS_URL from manifest

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -17,7 +17,6 @@ applications:
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
       CF_USERNAME: {{ cf_username }}
       CF_PASSWORD: {{ cf_password }}
-      REDIS_URL: {{ redis_url }}
     services:
       - notify-db
       - logit-ssl-syslog-drain


### PR DESCRIPTION
We're using a PaaS-provided redis service where we're binding to
directly.

This REDIS_URL has been removed from the creds repo anyway
(https://github.com/alphagov/notifications-credentials/pull/282)



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
