### PR TITLE
Raise max service callback workers from 30 to 45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ production:
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RESEARCH: 60" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_HIGH: 20" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_CALLBACK: 30" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_CALLBACK: 45" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_LOW: 5" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_MEDIUM: 10" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API_SMS_RECEIPTS: 15" >> data.yml


### PR DESCRIPTION
There are two reasons for this change

1. In recent weeks we have seen the service callbacks queue grow to over 30 minutes in elngth

2. We have an upcoming load test from a service that in the past has also caused delays of over 30 minutes on service callbacks

I think we should put in this change to reduce the impact to our users.

Although there has never been a clear understanding of what our users expectations are for when they should receive a callback (should it be instantly, maybe within a minute, or maybe just anytime later), I'm going to suggest that at least some will expect it to be pretty speedy and at least quicker than 30 minutes.

Therefore I think we should let this worker scale higher if it needs to.

We have in the past talked about the theoretical denial of service of some user services if we start sending callbacks to them at a very quick rate (due to more callback workers), however we have increased the callback worker instances several times over the past few years and had no reports of this happening in practice. Lets bite the bullet and see if it causes a problem (I reckon it won't) and then decide rather than risking 30 minute delays to callbacks happening too often.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
