### PR TITLE
Add scaling for `notify-delivery-worker-sender-letters`

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -67,6 +67,14 @@ APPS:
           weekends:
             - 08:00-23:00
 
+  - name: notify-delivery-worker-sender-letters
+    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
+    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
+    scalers:
+      - type: SqsScaler
+        queues: [send-letter-tasks]
+        threshold: 250
+
   - name: notify-delivery-worker-jobs
     min_instances: {{ MIN_INSTANCE_COUNT_JOBS }}
     max_instances: {{ MAX_INSTANCE_COUNT_JOBS }}


### PR DESCRIPTION
This adds the `SqsScaler` to the new `notify-delivery-worker-sender-letters` app. Since this isn't running yet we are not sure how long each task will take but can change the number of instances following the planned load tests. The main thing we want to avoid here is exceeding DVLA's rate limit of 50 requests per second. Using a maximum of 5 instances in production should avoid going over the limit, but we may find that we can have more instances after testing.

**Merge after**
- [x] https://github.com/alphagov/notifications-api/pull/3733
- [x] We have created the `send-letter-tasks` queue in each environment

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
