### PR TITLE
Remove priority app autoscaling as this app is being deleted

### DIFF
--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -114,14 +114,6 @@ APPS:
         queues:  [research-mode-tasks]
         threshold: 250
 
-  - name: notify-delivery-worker-priority
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
-    scalers:
-      - type: SqsScaler
-        queues:  [priority-tasks]
-        threshold: 250
-
   - name: notify-delivery-worker-periodic
     min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
     max_instances: {{ MAX_INSTANCE_COUNT_LOW }}


### PR DESCRIPTION
Similar to https://github.com/alphagov/notifications-aws/pull/1474



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
