### PR TITLE
Add SQLALCHEMY_DATABASE_URI environment variable to override postgres uri

### DIFF
--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -63,6 +63,9 @@ class DbQueryScaler(BaseScaler):
         self.last_db_error = datetime.min
 
     def _init_db_uri(self):
+        if "SQLALCHEMY_DATABASE_URI" in os.environ:
+            self.db_uri = os.environ["SQLALCHEMY_DATABASE_URI"].replace("postgresql://", "postgres://")
+            return
         try:
             self.db_uri = json.loads(os.environ["VCAP_SERVICES"])["postgres"][0]["credentials"]["uri"]
         except KeyError as e:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -17,6 +17,9 @@ applications:
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
       CF_USERNAME: {{ cf_username }}
       CF_PASSWORD: {{ cf_password }}
+      {% if sqlalchemy_database_uri is defined %}
+      SQLALCHEMY_DATABASE_URI: '{{ sqlalchemy_database_uri }}'
+      {% endif %}
     services:
       - notify-db
       - logit-ssl-syslog-drain

--- a/tests/test_base_scalers.py
+++ b/tests/test_base_scalers.py
@@ -121,3 +121,14 @@ class TestDbQueryScaler:
         self.db_query_scaler.run_query()
 
         assert mock_db_connection.called is True
+
+
+@freeze_time("2018-01-01 12:00")
+class TestDbQueryScalerWithFixedCredentials:
+    def setup_method(self, method):
+        with patch.dict(os.environ, {"SQLALCHEMY_DATABASE_URI": "postgresql://test-db-uri"}):
+            self.db_query_scaler = DbQueryScaler(app_name, min_instances, max_instances)
+            self.db_query_scaler.query = "foo"
+
+    def test_db_uri_is_loaded(self):
+        assert self.db_query_scaler.db_uri == "postgres://test-db-uri"


### PR DESCRIPTION
Add SQLALCHEMY_DATABASE_URI environment variable to override 

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
