### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-boto3==1.21.35
-cloudfoundry-client==1.25.0
+boto3==1.28.7
+cloudfoundry-client==1.35.2
 psycopg2-binary==2.9.3
-pyyaml==5.4.1
+pyyaml==6.0.1
 redis==4.1.4
 pytz==2022.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,15 +12,15 @@ async-timeout==4.0.2
     # via aiohttp
 attrs==21.4.0
     # via aiohttp
-awscli==1.22.90
+awscli==1.29.7
     # via notifications-utils
 bleach==4.1.0
     # via notifications-utils
-boto3==1.21.35
+boto3==1.28.7
     # via
     #   -r requirements.in
     #   notifications-utils
-botocore==1.24.35
+botocore==1.31.7
     # via
     #   awscli
     #   boto3
@@ -37,7 +37,7 @@ charset-normalizer==2.0.12
     #   requests
 click==8.1.2
     # via flask
-cloudfoundry-client==1.25.0
+cloudfoundry-client==1.35.2
     # via -r requirements.in
 colorama==0.4.3
     # via awscli
@@ -87,7 +87,7 @@ multidict==6.0.2
     #   yarl
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.2
     # via -r requirements.in
-oauth2-client==1.2.1
+oauth2-client==1.4.2
     # via cloudfoundry-client
 orderedset==2.0.3
     # via notifications-utils
@@ -97,7 +97,7 @@ packaging==21.3
     #   redis
 phonenumbers==8.12.46
     # via notifications-utils
-polling2==0.4.6
+polling2==0.5.0
     # via cloudfoundry-client
 protobuf==3.20.2
     # via cloudfoundry-client
@@ -119,7 +119,7 @@ pytz==2022.1
     # via
     #   -r requirements.in
     #   notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   awscli
@@ -137,7 +137,7 @@ requests==2.27.1
     #   oauth2-client
 rsa==4.7.2
     # via awscli
-s3transfer==0.5.2
+s3transfer==0.6.1
     # via
     #   awscli
     #   boto3
@@ -158,7 +158,7 @@ urllib3==1.26.9
     #   requests
 webencodings==0.5.1
     # via bleach
-websocket-client==0.54.0
+websocket-client==1.6.1
     # via cloudfoundry-client
 werkzeug==2.1.1
     # via flask


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump boto3, botocore, s3transfer, oauth2-client, polling2, and some others as well.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
