### PR TITLE
Autoscaler talks to redis.

### DIFF
--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -16,7 +16,7 @@ from app.utils import get_statsd_client
 
 
 def _get_redis_url():
-    if "VCAP_SERVICES" in os.environ:
+    if "REDIS_URL" not in os.environ:
         try:
             return json.loads(os.environ["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
         except Exception:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -20,6 +20,9 @@ applications:
       {% if sqlalchemy_database_uri is defined %}
       SQLALCHEMY_DATABASE_URI: '{{ sqlalchemy_database_uri }}'
       {% endif %}
+      {% if REDIS_URL is defined %}
+      REDIS_URL: '{{ REDIS_URL }}'
+      {% endif %}
     services:
       - notify-db
       - logit-ssl-syslog-drain


### PR DESCRIPTION
We want the PaaS side apps (including autoscaler) to "talk" to redis on ecs Added the If statement on the manifest.yml.j2 to check if the redis_url is defined. It is then assumed the value from the credentials file. If not it will load the value from the VCAP_SERVICERS. I coukld not find a valid reason to keep the checking of existence or not of the VCAP_SERVICES, hence I removed it from the autoscaler.py file where I check for the presence of the redis_url loaded in the os.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
