### PR TITLE
Use lowercase for REDIS_URL

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -21,8 +21,8 @@ applications:
       {% if sqlalchemy_database_uri is defined %}
       SQLALCHEMY_DATABASE_URI: '{{ sqlalchemy_database_uri }}'
       {% endif %}
-      {% if REDIS_URL is defined %}
-      REDIS_URL: '{{ REDIS_URL }}'
+      {% if redis_url is defined %}
+      REDIS_URL: '{{ redis_url }}'
       {% endif %}
     services:
       - notify-db


### PR DESCRIPTION
This is for consistency with the other env vars that we read from the creds repo



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
