### PR TITLE
Scale up periodic worker by 4 instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_PERIODIC: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_PERIODIC: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 1" >> data.yml
@@ -64,6 +66,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_PERIODIC: 2" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_PERIODIC: 5" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml
@@ -100,6 +104,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 35" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_PERIODIC: 6" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_PERIODIC: 9" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 50" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 18" >> data.yml
@@ -171,6 +177,8 @@ test-data:
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_TEMPLATE_PREVIEW_CELERY: 20" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_PERIODIC: 6" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_PERIODIC: 9" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RECEIPTS: 4" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_RECEIPTS: 20" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_SENDER: 4" >> data.yml

--- a/config.tpl.yml
+++ b/config.tpl.yml
@@ -115,8 +115,8 @@ APPS:
         threshold: 250
 
   - name: notify-delivery-worker-periodic
-    min_instances: {{ MIN_INSTANCE_COUNT_LOW }}
-    max_instances: {{ MAX_INSTANCE_COUNT_LOW }}
+    min_instances: {{ MIN_INSTANCE_COUNT_PERIODIC }}
+    max_instances: {{ MAX_INSTANCE_COUNT_PERIODIC }}
     scalers:
       - type: SqsScaler
         queues:  [periodic-tasks]


### PR DESCRIPTION
https://github.com/alphagov/notifications-api/pull/3918

That PR is going to put 4 long running tasks on the periodic workers. So we don't take up all the periodic worker doing those tasks (which would block them picking up other things like sending scheduled jobs), we need to increase the minimum and max number of instances on the assumption that 4 of them will be running the above task all the time.

It does make the assumption that the task above will take less than 24 hours (otherwise, we will go from having 4 running tasks to having 8 running tasks).



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
