### PR TITLE
Scale down broadcasts worker to 1 in all environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ preview:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 1" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 1" >> data.yml
@@ -78,8 +78,8 @@ staging:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 2" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 2" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 25" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 4" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml
@@ -116,8 +116,8 @@ production:
 	@echo "MAX_INSTANCE_COUNT_REPORTING: 3" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_JOBS: 2" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_JOBS: 25" >> data.yml
-	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
-	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 2" >> data.yml
+	@echo "MIN_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
+	@echo "MAX_INSTANCE_COUNT_BROADCASTS: 1" >> data.yml
 	@echo "MAX_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_API: 35" >> data.yml
 	@echo "MIN_INSTANCE_COUNT_RESEARCH: 2" >> data.yml


### PR DESCRIPTION
One, this will save us money as it is no longer used.

Two, it will reduce the throughput on a task I've put on the broadcast worker which may be having a small impact on production api response times. This will slow it down and reduce that until we are happy to scale it back up more.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
