### PR TITLE
Bump black to 23.10.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     - id: isort
       name: isort (python)
 - repo: https://github.com/psf/black
-  rev: 22.8.0
+  rev: 23.10.1
   hooks:
     - id: black
       name: black (python)

--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -110,7 +110,6 @@ class Autoscaler:
 
         # scale down
         if desired < current:
-
             if self._recent_scale(app_name, "last_scale_up", self.cooldown_seconds_after_scale_up):
                 logging.debug("Skipping scale down due to recent scale up event")
                 return current

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ oauth2-client==1.4.2
     # via cloudfoundry-client
 orderedset==2.0.3
     # via notifications-utils
-packaging==21.3
+packaging==23.2
     # via
     #   bleach
     #   redis
@@ -105,8 +105,6 @@ psycopg2-binary==2.9.3
     # via -r requirements.in
 pyasn1==0.4.8
     # via rsa
-pyparsing==3.0.7
-    # via packaging
 pypdf2==1.27.5
     # via notifications-utils
 pyproj==3.3.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,6 +7,6 @@ pytest-cov==3.0.0
 pytest-mock==3.7.0
 pytest-randomly==3.11.0
 pytest==7.1.1
-black==22.8.0  # Also update `.pre-commit-config.yaml` if this changes
+black==23.10.1  # Also update `.pre-commit-config.yaml` if this changes
 
 -r requirements.txt

--- a/tests/test_base_scalers.py
+++ b/tests/test_base_scalers.py
@@ -40,7 +40,6 @@ class TestBaseScaler:
     def test_get_desired_instance_count_is_normalized(
         self, min_instances, max_instances, desired_instances, expected_instances
     ):
-
         base_scaler = BaseScaler(app_name, min_instances, max_instances)
         with patch.object(base_scaler, "_get_desired_instance_count", side_effect=[desired_instances]):
             assert base_scaler.get_desired_instance_count() == expected_instances


### PR DESCRIPTION

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
