### PR TITLE
Remove redis and db

### DIFF
--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -18,14 +18,6 @@ from app.utils import get_statsd_client
 def _get_redis_url():
     if "REDIS_URL" in os.environ:
         return os.environ["REDIS_URL"]
-    elif "VCAP_SERVICES" in os.environ:
-        try:
-            return json.loads(os.environ["VCAP_SERVICES"])["redis"][0]["credentials"]["uri"]
-        except Exception:
-            logging.exception(
-                "Could not find notify-redis credentials. "
-                "Ensure the app is running on paas and bound to the redis service."
-            )
     return "redis://redis.local"
 
 

--- a/app/autoscaler.py
+++ b/app/autoscaler.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import logging
 import os
 import sched

--- a/app/base_scalers.py
+++ b/app/base_scalers.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from datetime import datetime, timedelta
@@ -63,15 +62,8 @@ class DbQueryScaler(BaseScaler):
         self.last_db_error = datetime.min
 
     def _init_db_uri(self):
-        if "SQLALCHEMY_DATABASE_URI" in os.environ:
-            self.db_uri = os.environ["SQLALCHEMY_DATABASE_URI"].replace("postgresql://", "postgres://")
-            return
-        try:
-            self.db_uri = json.loads(os.environ["VCAP_SERVICES"])["postgres"][0]["credentials"]["uri"]
-        except KeyError as e:
-            msg = str(e)
-            logging.error(msg)
-            self.db_uri = None
+        self.db_uri = os.environ["SQLALCHEMY_DATABASE_URI"].replace("postgresql://", "postgres://")
+        return
 
     def run_query(self):
         if datetime.utcnow() - self.last_db_error < self.DB_CONNECTION_TIMEOUT:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -21,10 +21,7 @@ applications:
       {% if sqlalchemy_database_uri is defined %}
       SQLALCHEMY_DATABASE_URI: '{{ sqlalchemy_database_uri }}'
       {% endif %}
-      {% if redis_url is defined %}
       REDIS_URL: '{{ redis_url }}'
-      {% endif %}
     services:
       - notify-db
       - logit-ssl-syslog-drain
-      - notify-redis

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -18,10 +18,7 @@ applications:
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
       CF_USERNAME: {{ cf_username }}
       CF_PASSWORD: {{ cf_password }}
-      {% if sqlalchemy_database_uri is defined %}
       SQLALCHEMY_DATABASE_URI: '{{ sqlalchemy_database_uri }}'
-      {% endif %}
       REDIS_URL: '{{ redis_url }}'
     services:
-      - notify-db
       - logit-ssl-syslog-drain

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 
@@ -209,6 +210,7 @@ scale_factor: 0.8
         mock_paas_client = mocker.patch("app.autoscaler.PaasClient")
         mocker.patch("app.autoscaler.Redis", fakeredis.FakeRedis)
         mock_get_statsd_client = mocker.patch("app.autoscaler.get_statsd_client")
+        mocker.patch.dict(os.environ, {"SQLALCHEMY_DATABASE_URI": "test-db-uri"})
 
         mock_paas_client.return_value.get_paas_apps.return_value = {
             app_name: {"name": app_name, "instances": 5, "guid": app_name + "-guid"},

--- a/tests/test_base_scalers.py
+++ b/tests/test_base_scalers.py
@@ -1,4 +1,3 @@
-import json
 import os
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -89,8 +88,7 @@ def mock_db_connection():
 @freeze_time("2018-01-01 12:00")
 class TestDbQueryScaler:
     def setup_method(self, method):
-        vcap_string = json.dumps({"postgres": [{"credentials": {"uri": "test-db-uri"}}]})
-        with patch.dict(os.environ, {"VCAP_SERVICES": vcap_string}):
+        with patch.dict(os.environ, {"SQLALCHEMY_DATABASE_URI": "test-db-uri"}):
             self.db_query_scaler = DbQueryScaler(app_name, min_instances, max_instances)
             self.db_query_scaler.query = "foo"
 

--- a/tests/test_scheduled_jobs_scaler.py
+++ b/tests/test_scheduled_jobs_scaler.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+import os
+from unittest.mock import Mock, patch
 
 from app.scheduled_jobs_scaler import ScheduledJobsScaler
 
@@ -12,7 +13,8 @@ class TestScheduledJobsScaler:
         input_attrs = {
             "threshold": 1500,
         }
-        scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
+        with patch.dict(os.environ, {"SQLALCHEMY_DATABASE_URI": "test-db-uri"}):
+            scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
 
         assert scheduled_job_scaler.app_name == app_name
         assert scheduled_job_scaler.min_instances == min_instances
@@ -32,7 +34,8 @@ class TestScheduledJobsScaler:
         input_attrs = {
             "threshold": 1500,
         }
-        scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
+        with patch.dict(os.environ, {"SQLALCHEMY_DATABASE_URI": "test-db-uri"}):
+            scheduled_job_scaler = ScheduledJobsScaler(app_name, min_instances, max_instances, **input_attrs)
         scheduled_job_scaler.run_query = Mock(return_value=10000)
 
         # 10k items * 0.3 = 3k => 2 instances


### PR DESCRIPTION
Review commit by commit

Unbinds and drops support for both the PaaS redis and the PaaS postgres (both will need a manual unbinding for it to take affect)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
